### PR TITLE
Add initial website structure and property details

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -11,18 +11,57 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addWatchTarget('./js');
   eleventyConfig.addWatchTarget('./image');
 
-  // Note: The project currently stores static pages under `pages/`.
-  // We configure Eleventy to use that as the input so Netlify builds `_site` correctly.
+  // Copy static HTML under pages/ to the site root so existing pages still deploy
+  eleventyConfig.addPassthroughCopy({ pages: '.' });
+
+  // Load page JSON documents under content/pages into a global map: pages[slug]
+  const contentRoot = path.join(__dirname, 'content');
+  const pagesDir = path.join(contentRoot, 'pages');
+  const pagesMap = {};
+  if (fs.existsSync(pagesDir)) {
+    for (const file of fs.readdirSync(pagesDir)) {
+      if (file.endsWith('.json')) {
+        const slug = file.replace(/\.json$/, '');
+        try {
+          const raw = fs.readFileSync(path.join(pagesDir, file), 'utf8');
+          pagesMap[slug] = JSON.parse(raw);
+        } catch (e) {
+          console.warn('Failed parsing page JSON:', file, e);
+        }
+      }
+    }
+  }
+  eleventyConfig.addGlobalData('pages', pagesMap);
+
+  // Build collection from property JSON files under content/properties
+  eleventyConfig.addCollection('property', function () {
+    const propertiesDir = path.join(contentRoot, 'properties');
+    const items = [];
+    if (fs.existsSync(propertiesDir)) {
+      for (const file of fs.readdirSync(propertiesDir)) {
+        if (file.endsWith('.json')) {
+          const slug = file.replace(/\.json$/, '');
+          try {
+            const raw = fs.readFileSync(path.join(propertiesDir, file), 'utf8');
+            const data = JSON.parse(raw);
+            items.push({ fileSlug: slug, data, inputPath: path.join('content/properties', file) });
+          } catch (e) {
+            console.warn('Failed parsing property JSON:', file, e);
+          }
+        }
+      }
+    }
+    return items;
+  });
 
   return {
     dir: {
-      input: 'pages',
+      input: 'content',
       output: '_site',
       includes: '_includes',
       data: '_data'
     },
-    // Limit to HTML so it doesn't attempt to process other files at repo root
-    templateFormats: ['html']
+    templateFormats: ['njk', 'html']
   };
 };
 

--- a/_site/404.html
+++ b/_site/404.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html><html lang="lv" data-sb-object-id="content/pages/404.json"><head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;600&family=Noto+Serif:wght@700&display=swap&subset=latin-ext" rel="stylesheet">
+    <link rel="stylesheet" href="../css/style.css">
+    <link rel="stylesheet" href="../css/changes.css">
+    <link rel="stylesheet" href="../css/custom.css">
+    <link rel="stylesheet" href="../css/fonts.css">
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.2/animation_utility.css">
+    <link rel="icon" type="image/x-icon" href="../image/red_LOGO_Vandore.png?v=2025">
+    <title data-i18n="vandore_heritage_404_not_found" data-sb-field-path="title">Vandore Heritage - 404 nav atrasts</title>
+</head>
+
+<body>
+    <!-- Scripts -->
+    <script src="../js/vendor/jquery.min.js"></script>
+
+    <main>
+        <div class="section bg-black-1 position-relative">
+            <a href="index.html" class="d-flex" style="justify-self: end;">
+                <i class="rtmicon rtmicon-arrow-left fs-1 fw-bold accent-primary"></i>
+            </a>
+            <div class="position-absolute" style="right: 5rem; top: 13em;">
+                <div class="d-flex flex-column gap-5 accent-primary text-end">
+                    <div class="d-flex flex-column gap-4">
+                        <h6 data-i18n="riga_latvia">Rīga, Latvija</h6>
+                        <div class="d-flex flex-column gap-3">
+                            <span data-i18n="skanstes_iela_29a91_rga_latvia">
+                                Skanstes Iela 29A - 91, Rīga, Latvija
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="r-container h-100" style="margin-bottom: 10rem;">
+                <div>
+                    <h1 data-sb-field-path="heroHeading" class="visually-hidden">404 - Page Not Found</h1>
+                    <div class="w-100 h-100 d-flex flex-column gap-5 me-auto justify-content-center scrollanimation animated zoomIn accent-primary" style="max-width: 900px;">
+                    <div class="d-flex flex-row gap-5 align-items-center">
+                        <span class="display" data-i18n="404">404</span>
+                        <img src="../image/dummy-img-600x400.jpg" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Page not found illustration">
+                    </div>
+                    <h3 data-i18n="ooops_the_property_youre_looking_for_is_no_longer_available">Ooops, jūsu meklētais īpašums vairs nav pieejams.</h3>
+                    <div class="w-max-content">
+                        <a href="index.html" class="btn btn-accent accent d-flex flex-row gap-2 px-4 py-3">
+                            <span data-i18n="back_to_home">Atpakaļ uz mājām</span>
+                            <i class="rtmicon rtmicon-arrow-up-right fw-bold"></i>
+                        </a>
+                    </div>
+                    </div>
+                </div>
+            </div>
+            <div class="d-flex flex-column gap-3 accent-primary">
+                <h6 data-i18n="vandore_heritage">Vandore mantojums</h6>
+                <div class="d-flex flex-column gap-2">
+                    <div class="d-flex flex-row gap-2">
+                        <a href="property_details.html" class="d-flex flex-row gap-2 align-items-center tags">
+                            <i class="rtmicon rtmicon-arrow-right fs-5"></i>
+                            <span data-i18n="property_details">Īpašuma informācija</span>
+                        </a>
+                        <a href="team.html" class="d-flex flex-row gap-2 align-items-center tags">
+                            <i class="rtmicon rtmicon-arrow-right fs-5"></i>
+                            <span data-i18n="our_team">Mūsu komanda</span>
+                        </a>
+                        <a href="price_plan.html" class="d-flex flex-row gap-2 align-items-center tags">
+                            <i class="rtmicon rtmicon-arrow-right fs-5"></i>
+                            <span data-i18n="pricing_plan">Cenu plāns</span>
+                        </a>
+                    </div>
+                    <div class="d-flex flex-row gap-2">
+                        <a href="faq.html" class="d-flex flex-row gap-2 align-items-center tags">
+                            <i class="rtmicon rtmicon-arrow-right fs-5"></i>
+                            <span data-i18n="faqs">FAQ</span>
+                        </a>
+                        <a href="404.html" class="d-flex flex-row gap-2 align-items-center tags active">
+                            <i class="rtmicon rtmicon-arrow-right fs-5"></i>
+                            <span data-i18n="404_page">404 lappuse</span>
+                        </a>
+                        <a href="single_blog.html" class="d-flex flex-row gap-2 align-items-center tags">
+                            <i class="rtmicon rtmicon-arrow-right fs-5"></i>
+                            <span data-i18n="single_post">Vienreizējs amats</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <!-- Back to top button -->
+    <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="rtmicon rtmicon-arrow-up"></i></a>
+
+    <script src="../js/vendor/bootstrap.bundle.min.js"></script>
+    <script src="../js/vendor/swiper-bundle.min.js"></script>
+    <script src="../js/script.js"></script>
+    <script src="../js/swiper-script.js"></script>
+    <script src="../js/submit-form.js"></script>
+    <script src="../js/vendor/isotope.pkgd.min.js"></script>
+    <script src="../js/video_embedded.js"></script>
+    <script src="../js/share.js"></script>
+    <script src="../js/custom.js"></script>
+    <script src="../js/vendor/fslightbox.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.0/oyethemes_onscroll_animation.js"></script>
+
+
+
+</body></html>

--- a/_site/about.html
+++ b/_site/about.html
@@ -1,0 +1,433 @@
+<!DOCTYPE html><html lang="lv" data-sb-object-id="content/pages/about.json"><head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;600&family=Noto+Serif:wght@700&display=swap&subset=latin-ext" rel="stylesheet">
+    <link rel="stylesheet" href="../css/style.css">
+    <link rel="stylesheet" href="../css/changes.css">
+    <link rel="stylesheet" href="../css/custom.css">
+    <link rel="stylesheet" href="../css/fonts.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.2/animation_utility.css">
+    <link rel="icon" type="image/x-icon" href="../image/red_LOGO_Vandore.png?v=2025">
+<title data-i18n="vandore_heritage_about_us" data-sb-field-path="title">Vandore Heritage - par mums</title>
+</head>
+
+<body>
+    <!-- Header -->
+    <header class="bg-accent-primary px-5">
+        <nav class="navbar">
+            <div class="container-fluid ps-3 gap-3">
+                <div class="me-auto"></div>
+                <div class="logo-container position-absolute start-50 translate-middle-x">
+                    <a class="navbar-brand" href="index.html"><img src="../image/red_LOGO_Vandore.png?v=2025" alt="Vandore Heritage Logo" class="img-fluid"></a>
+                </div>
+                <div class="w-max-content">
+                    <button class="btn btn-toggler-accent" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDark" aria-controls="offcanvasDark"><i class="fa-solid fa-bars"></i>
+                        Menu</button>
+
+                    <div class="offcanvas offcanvas-end offcanvas-fullwidth text-bg-dark" tabindex="-1" id="offcanvasDark" aria-labelledby="offcanvasRightLabel">
+                        <div class="offcanvas-header bg-transparent">
+                            <h5 id="offcanvasRightLabel">Menu</h5>
+                            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+                        </div>
+                        <div class="offcanvas-body">
+                            <div class="r-container">
+                                <div class="row row-cols-xl-2 row-cols-1">
+                                    <div class="col col-xl-10 mb-3">
+                                        <div class="d-flex flex-column">
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="01_homepage">01. Mājas lapa</span>
+                                                <img src="../image/img6.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="index.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="02_properties">02. Īpašumi</span>
+                                                <img src="../image/img5.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="properties.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="03_short_form_rentals">03. Īsas formas īre</span>
+                                                <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="rentals.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="04_about_us">04. Par mums</span>
+                                                <img src="../image/img33.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="about.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="05_services">05. Pakalpojumi</span>
+                                                <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="service.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="06_contact">06. Sazinieties</span>
+                                                <img src="../image/img29.png" class="img-fluid rounded-3 " style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="contact.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="07_news">07. Jaunumi</span>
+                                                <img src="../image/img26.png" class="img-fluid rounded-3 " style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="blog.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col col-xl-2 mb-3">
+                                        <div class="d-flex flex-column gap-5 accent-primary text-end">
+                                           <div class="d-flex flex-column gap-4">
+                                                <h6 data-i18n="riga_latvia">Rīga, Latvija</h6>
+                                                <div class="d-flex flex-column gap-3">
+                                                    <span data-i18n="skanstes_iela_29a91_rga_latvia">
+                                                        Skanstes Iela 29A - 91, Rīga, Latvija
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </nav>
+    </header>
+    <!-- End Header -->
+
+    <!-- Main -->
+    <main>
+        <!-- Banner -->
+        <div class="section position-relative bg-attach-cover">
+            <div class="r-container position-relative h-100">
+                <div class="position-absolute top-0 start-0 end-0 bottom-0 h-100 w-100" style="margin-top: 10rem;">
+                    <div class="row row-cols-2">
+                        <div class="col-3 col-xl-2"></div>
+                        <div class="col-9 col-xl-10">
+                            <img src="../image/dummy-img-1920x900.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Vandore Heritage">
+                        </div>
+                    </div>
+                </div>
+                <div class="d-flex flex-column gap-5 justify-content-between scrollanimation animated fadeInLeft adr-7 h-100 padding-custom">
+                    <div class="d-flex flex-column gap-2 h-100">
+                        <div><h1 class="display" style="max-width: 700px;" data-i18n="about_us" data-sb-field-path="heroHeading">Par mums</h1>
+                        <div class="row row-cols-1">
+                            <div class="col col-xl-4">
+                                <div class="d-flex flex-column gap-2 align-items-xl-center align-items-start">
+                                    <p data-i18n="vandore_heritage_began_with_a_conversation_not_about_how_to_sell_more_but_about_how_to_do_things_right" data-sb-field-path="heroSubheading">Vandore Heritage sākās ar sarunu - nevis par to, kā pārdot vairāk, bet gan par to, kā rīkoties pareizi.</p></div>
+                                    <div class="devider"></div>
+                                </div>
+                            </div>
+                            <div class="col col-xl-10"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Section About Us -->
+        <div class="section">
+            <div class="r-container d-flex flex-column gap-5">
+                <div class="row row-cols-xl-2 row-cols-1">
+                    <div class="col mb-3 scrollanimation animated fadeInLeft adr-7">
+                        <div class="d-flex flex-column gap-5">
+                            <img src="../image/dummy-img-600x700.jpg" class="img-fluid custom-border rounded-2 w-100" style="aspect-ratio: 5/6;" alt="Vandore Heritage team members working together">
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col mb-3 scrollanimation animated fadeInDown adr-7">
+                        <div class="d-flex flex-column gap-2 ps-5">
+                            <h3 data-i18n="this_isnt_just_business_its_an_attitude">Tas nav tikai bizness - tā ir attieksme.</h3>
+                            <p data-i18n="we_look_beyond_square_meters_and_transactions_into_how_a_space_makes_you_feel_how_it_shapes_decisions_and_life_and_the_role_we_play_in_those_stories_vandore_heritage_came_to_life_not_as_another_agency_but_as_a_brand_that_stands_for_quality_for_respect_toward_architecture_design_and_people_for_longterm_relationships_built_on_trust_and_results_not_big_promises_vandore_heritage_is_our_promise_to_work_with_care_and_to_stay_present_beyond_the_deal">
+                                Mēs skatāmies ārpus kvadrātmetriem un darījumiem - par to, kā telpa liek justies, kā tā veido lēmumus un dzīvi, kā arī lomu, ko mēs spēlējam šajos stāstos. Vandore Heritage atdzīvojās nevis kā cita aģentūra, bet gan kā zīmols, kas apzīmē kvalitāti. Par cieņu pret arhitektūru, dizainu un cilvēkiem. Ilgtermiņa attiecībām, kas balstītas uz uzticību un rezultātiem, nevis lieliem solījumiem. Vandore Heritage ir mūsu solījums: strādāt uzmanīgi, palikt klāt ārpus darījuma.
+                            </p>
+                            
+                            <div class="d-flex flex-column gap-4 w-100">
+                                <div class="accordion accent mt-3 d-flex flex-column gap-4" id="faqAccordion1">
+                                    <div class="accordion-item">
+                                        <h2 class="accordion-header">
+                                            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#faq1" aria-expanded="true" aria-controls="faq1" data-i18n="what_makes_you_different_from_other_agencies">
+                                                Kas padara jūs atšķirīgu no citām aģentūrām?
+                                            </button>
+                                        </h2>
+                                        <div id="faq1" class="accordion-collapse collapse show" data-bs-parent="#faqAccordion1">
+                                            <div class="accordion-body" data-i18n="a_wide_adaptable_service_set_from_sales_and_rentals_to_renovation_design_legal_support_and_branding_delivered_with_careful_attention_to_detail">
+                                                Plašs, pielāgojams pakalpojumu komplekts - sākot no pārdošanas un īres līdz atjaunošanai, dizainam, juridiskam atbalstam un zīmolam -, kas rūpīgi pievērš uzmanību detaļām.
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="accordion-item">
+                                        <h2 class="accordion-header">
+                                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq2" aria-expanded="false" aria-controls="faq2" data-i18n="do_you_only_work_with_luxury_properties">
+                                                Vai jūs strādājat tikai ar luksusa īpašumiem?
+                                            </button>
+                                        </h2>
+                                        <div id="faq2" class="accordion-collapse collapse" data-bs-parent="#faqAccordion1">
+                                            <div class="accordion-body" data-i18n="partly_we_work_with_exclusive_properties_across_latvia_and_also_with_projects_that_show_potential">
+                                                Daļēji. Mēs strādājam ar ekskluzīviem īpašumiem visā Latvijā, kā arī ar projektiem, kas parāda potenciālu.
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="accordion-item">
+                                        <h2 class="accordion-header">
+                                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq3" aria-expanded="false" aria-controls="faq3" data-i18n="why_use_an_agent">
+                                                Kāpēc izmantot aģentu?
+                                            </button>
+                                        </h2>
+                                        <div id="faq3" class="accordion-collapse collapse" data-bs-parent="#faqAccordion1">
+                                            <div class="accordion-body" data-i18n="to_avoid_mistakes_maximize_potential_and_ensure_strategy_quality_presentation_clear_communication_and_legal_order">
+                                                Lai izvairītos no kļūdām, palieliniet potenciālu un nodrošinātu stratēģiju, kvalitatīvu prezentāciju, skaidru komunikāciju un likumīgo kārtību.
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        
+        
+        <div class="section bg-attach-cover" style="background-image: url(../image/bg_cta.png);">
+            <!-- Section Our Team -->
+            <div class="r-container d-flex flex-column gap-5" style="margin-bottom: 6em;">
+                <div class="row row-cols-xl-2 row-cols-1 align-items-end" data-sb-field-path="sections">
+                    <div class="col mb-3 scrollanimation animated fadeInLeft adr-7">
+                        <h3 style="max-width: 600px;" data-i18n="meet_the_team" data-sb-field-path="sections[0].heading">Satikt komandu</h3>
+                    </div>
+                    <div class="col mb-3 scrollanimation animated fadeInDown adr-7">
+                        <div class="d-flex flex-column gap-2 align-items-end">
+                            <p data-i18n="backed_by_a_shared_vision_roberts_and_dolfs_lead_a_team_built_to_raise_the_standard_and_bring_a_new_kind_of_presence_to_the_industry" data-sb-field-path="sections[0].text">Roberts un Ādolfs, kas atbalsta kopīgu redzējumu, vada komandu, kas izveidota, lai paaugstinātu standartu un nodrošinātu nozarei jauna veida klātbūtni.</p>
+                            <div class="w-max-content" style="justify-self: end;">
+                                <a href="team.html" class="btn btn-accent-outline d-flex flex-row gap-2 justify-content-center">
+                                    <span data-i18n="view_all_team">Skatīt visu komandu</span>
+                                    <i class="rtmicon rtmicon-arrow-up-right fw-bold"></i>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="tab-container">
+                    <div class="tab-content">
+                        <div class="content active" id="team-1">
+                            <div class="d-flex flex-column h-100">
+                                <img src="../image/dummy-img-600x400.jpg" class="img-fluid h-100" style="aspect-ratio: 3/2;" alt="Vandore Heritage">
+                                <div class="d-flex flex-column gap-5 rounded-2 p-4 bg-gray-hover mx-4" style="margin-top: -105px;">
+                                    <div class="d-flex flex-column gap-2">
+                                        <h4 data-i18n="dolfs_mrti_krauklis">Ādolfs Mārtiņš Krauklis</h4>
+                                        <span data-i18n="cofounder">Līdzdibinātājs</span>
+                                    </div>
+                                    <div class="social-container" style="border-bottom-right-radius: 20px;">
+                                        <a href="https://www.facebook.com/share/1AwoA2Vb1U/?mibextid=wwXIfr" class="social-item" target="_blank">
+                                            <i class="fa-brands fa-xs fa-facebook-f"></i>
+                                        </a>
+                                        <a href="https://www.instagram.com/vandoreheritage" class="social-item" target="_blank">
+                                            <i class="fa-brands fa-xs fa-instagram"></i>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="content" id="team-2">
+                             <div class="d-flex flex-column h-100">
+                                <img src="../image/dummy-img-600x400.jpg" class="img-fluid h-100" style="aspect-ratio: 3/2;" alt="Vandore Heritage">
+                                <div class="d-flex flex-column gap-5 rounded-2 p-4 bg-gray-hover mx-4" style="margin-top: -105px;">
+                                    <div class="d-flex flex-column gap-2">
+                                        <h4 data-i18n="roberts_punka">Roberts panka</h4>
+                                        <span data-i18n="cofounder">Līdzdibinātājs</span>
+                                    </div>
+                                    <div class="social-container" style="border-bottom-right-radius: 20px;">
+                                        <a href="https://www.facebook.com/share/1AwoA2Vb1U/?mibextid=wwXIfr" class="social-item" target="_blank">
+                                            <i class="fa-brands fa-xs fa-facebook-f"></i>
+                                        </a>
+                                        <a href="https://www.instagram.com/vandoreheritage" class="social-item" target="_blank">
+                                            <i class="fa-brands fa-xs fa-instagram"></i>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="tabs">
+                        <div class="tab active" data-tab="team-1">
+                            <div class="position-relative overflow-hidden">
+                                <img src="../image/dummy-img-600x400.jpg" class="img-fluid w-100 h-100" style="aspect-ratio: 3/2;" alt="Vandore Heritage">
+                                <div class="position-absolute start-0 bottom-0 accent-primary p-4">
+                                    <h5 data-i18n="dolfs_mrti_krauklis">Ādolfs Mārtiņš Krauklis</h5>
+                                    <span data-i18n="cofounder">Līdzdibinātājs</span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="tab" data-tab="team-2">
+                            <div class="position-relative overflow-hidden">
+                                <img src="../image/dummy-img-600x400.jpg" class="img-fluid w-100 h-100" style="aspect-ratio: 3/2;" alt="Vandore Heritage">
+                                <div class="position-absolute start-0 bottom-0 accent-primary p-4">
+                                    <h5 data-i18n="roberts_punka">Roberts panka</h5>
+                                    <span data-i18n="cofounder">Līdzdibinātājs</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <!-- Section CTA -->
+            <div class="r-container d-flex flex-column gap-3" style="margin-block: 6em;">
+                <div class="row row-cols-xl-2 row-cols-1">
+                    <div class="col col-xl-7 mb-3 scrollanimation animated fadeInLeft">
+                        <div class="d-flex flex-column gap-5 pe-xl-5">
+                            <h3 data-i18n="ready_to_work_with_vandore_heritage">Vai esat gatavs strādāt ar Vandore Heritage?</h3>
+                            <h6 data-i18n="leave_your_email_and_well_get_in_touch">Atstājiet savu e -pastu, un mēs sazināsimies.</h6>
+                            <div class="d-flex flex-column gap-3">
+                                <div class="toast-container position-fixed bottom-0 end-0 p-3">
+                                    <div id="liveToast" class="toast success_msg_subscribe bg-dark-transparent text-white" role="alert" aria-live="assertive" aria-atomic="true">
+                                        <div class="d-flex">
+                                            <div class="toast-body" data-i18n="your_subscribe_send_successfully">
+                                                Jūsu abonēšana veiksmīgi nosūta!.
+                                            </div>
+                                            <button type="button" class="btn me-2 m-auto text-white" data-bs-dismiss="toast" aria-label="Close">
+                                                <i class="fa-solid fa-xmark"></i>
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div>
+                                    <form class="d-flex flex-column h-100 justify-content-center w-100 needs-validation form" novalidate="">
+                                        <input type="text" name="action" value="subscribe" hidden="">
+                                        <div class="input-group gap-3 mb-xl-2 mb-0 position-relative">
+                                            <input type="email" class="form-control rounded-0 mb-xl-0 mb-3 subscribe" placeholder="Sign Up to Newsletter" name="email" required="">
+                                            <button class="btn btn-accent submit_subscribe rounded-0 gap-2 px-4 py-3" type="submit"><i class="rtmicon rtmicon-arrow-right fw-bold"></i></button>
+                                            <div class="invalid-feedback text-white" data-i18n="please_provide_a_valid_email_format_eg_userexamplecom">
+                                                Lūdzu, norādiet derīgu e -pasta formātu (piemēram, 
+user@example.com).
+                                            </div>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col col-xl-5 mb-3 scrollanimation animated fadeInRight">
+                        <img src="../image/dummy-img-600x400.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Contact us for real estate services">
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    </main>
+
+    <footer>
+        <div class="section position-relative bg-black-1" style="height: 90vh;">
+            <div class="row row-cols-xl-2 row-cols-1 h-100">
+                <div class="col col-xl-8 mb-3">
+                    <div class="d-flex flex-column gap-3 justify-content-between h-100">
+                        <div class="d-flex flex-column accent-primary">
+                            <p class="gray" data-i18n="get_contact">Sazināties</p>
+                            <h1 class="fw-normal" data-i18n="infovandoreheritagelv">info@vandoreheritage.lv</h1>
+                        </div>
+                        <img src="../image/logo-footer.png?v=2025" alt="Vandore Heritage" class="img-fluid" width="938">
+                    </div>
+                </div>
+                <div class="col col-xl-4 mb-3">
+                    <div class="d-flex flex-column gap-5 justify-content-between accent-primary h-100">
+                        <div class="d-flex flex-row gap-5">
+                            <ul class="list-unstyled d-flex flex-column gap-3 accent-color">
+                                <li>
+                                    <a href="index.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="home">
+                                        Mājas
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="about.html" class="link active d-flex flex-row gap-3 align-items-center" data-i18n="about">
+                                        Pret
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="properties.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="properties">
+                                        Īpašības
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="rentals.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="rentals">
+                                        Īre
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="service.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="service">
+                                        Sakārtošana
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="contact.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="contact_us">
+                                        Sazinieties ar mums
+                                    </a>
+                                </li>
+                            </ul>
+                            <div class="d-flex flex-column gap-3">
+                                <a href="https://www.google.com/maps/place/Skanstes+iela+29A,+Vidzemes+priekšpilsēta,+Rīga,+LV-1013,+Latvia" class="link" target="_blank" data-i18n="skanstes_iela_29a91_rga_latvia">
+                                    Skanstes Iela 29A - 91, Rīga, Latvija
+                                </a>
+                                <a href="tel:+37129713030" class="link" data-i18n="371_29_71_3030">
+                                    +371 29 71 3030 
+                                </a>
+                            </div>
+                        </div>
+                        <div class="d-flex flex-row gap-3">
+                            <div class="border-end pe-3 border-gray">
+                                <a href="" class="link d-flex flex-row gap-3 align-items-center" data-i18n="terms_conditions">
+                                    Noteikumi un nosacījumi
+                                </a>
+                            </div>
+                            <div>
+                                <a href="" class="link d-flex flex-row gap-3 align-items-center" data-i18n="privacy_notice">
+                                    Paziņojums par privātumu
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+
+    <!-- Back to top button -->
+    <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="rtmicon rtmicon-arrow-up"></i></a>
+
+    <!-- Scripts -->
+    <script src="../js/vendor/jquery.min.js"></script>
+    <script src="../js/vendor/bootstrap.bundle.min.js"></script>
+    <script src="../js/vendor/swiper-bundle.min.js"></script>
+    <script src="../js/script.js"></script>
+    <script src="../js/swiper-script.js"></script>
+    <script src="../js/submit-form.js"></script>
+    <script src="../js/vendor/isotope.pkgd.min.js"></script>
+    <script src="../js/video_embedded.js"></script>
+    <script src="../js/vendor/fslightbox.js"></script>
+    <script src="../js/custom.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.0/oyethemes_onscroll_animation.js"></script>
+
+
+</body></html>

--- a/_site/blog.html
+++ b/_site/blog.html
@@ -1,0 +1,383 @@
+<!DOCTYPE html><html lang="lv" data-sb-object-id="content/pages/blog.json"><head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;600&family=Noto+Serif:wght@700&display=swap&subset=latin-ext" rel="stylesheet">
+    <link rel="stylesheet" href="../css/style.css">
+    <link rel="stylesheet" href="../css/changes.css">
+    <link rel="stylesheet" href="../css/custom.css">
+    <link rel="stylesheet" href="../css/fonts.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.2/animation_utility.css">
+    <link rel="icon" type="image/x-icon" href="../image/red_LOGO_Vandore.png?v=2025">
+    <title data-i18n="vandore_heritage_blog" data-sb-field-path="title">Vandore Heritage - emuārs</title>
+</head>
+
+<body>
+    <!-- Header -->
+    <header class="bg-accent-primary px-5">
+        <nav class="navbar">
+            <div class="container-fluid ps-3 gap-3">
+                <div class="me-auto"></div>
+                <div class="logo-container position-absolute start-50 translate-middle-x" style="margin-top: 2cm;">
+                    <a class="navbar-brand" href="index.html"><img src="../image/red_LOGO_Vandore.png?v=2025" alt="Vandore Heritage" class="img-fluid"></a>
+                </div>
+                <div class="w-max-content" style="margin-top: 0.5cm;">
+                    <button class="btn btn-toggler-accent" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDark" aria-controls="offcanvasDark"><i class="fa-solid fa-bars"></i>
+                        Menu</button>
+
+                    <div class="offcanvas offcanvas-end offcanvas-fullwidth text-bg-dark" tabindex="-1" id="offcanvasDark" aria-labelledby="offcanvasRightLabel">
+                        <div class="offcanvas-header bg-transparent">
+                            <h5 id="offcanvasRightLabel">Menu</h5>
+                            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+                        </div>
+                        <div class="offcanvas-body">
+                            <div class="r-container">
+                                <div class="row row-cols-xl-2 row-cols-1">
+                                    <div class="col col-xl-10 mb-3">
+                                        <div class="d-flex flex-column">
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="01_homepage">01. Mājas lapa</span>
+                                                <img src="../image/img6.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="index.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="02_properties">02. Īpašumi</span>
+                                                <img src="../image/img5.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="properties.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="03_short_form_rentals">03. Īsas formas īre</span>
+                                                <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="rentals.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="04_about_us">04. Par mums</span>
+                                                <img src="../image/img33.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="about.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="05_services">05. Pakalpojumi</span>
+                                                <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="service.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="06_contact">06. Sazinieties</span>
+                                                <img src="../image/img29.png" class="img-fluid rounded-3 " style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="contact.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="07_news">07. Jaunumi</span>
+                                                <img src="../image/img26.png" class="img-fluid rounded-3 " style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="blog.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col col-xl-2 mb-3">
+                                        <div class="d-flex flex-column gap-5 accent-primary text-end">
+                                           <div class="d-flex flex-column gap-4">
+                                                <h6 data-i18n="riga_latvia">Rīga, Latvija</h6>
+                                                <div class="d-flex flex-column gap-3">
+                                                    <span data-i18n="skanstes_iela_29a91_rga_latvia">
+                                                        Skanstes Iela 29A - 91, Rīga, Latvija
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </nav>
+    </header>
+    <!-- End Header -->
+
+    <!-- Main -->
+    <main>
+        <!-- Banner -->
+        <div class="section position-relative bg-attach-cover">
+            <div class="r-container position-relative h-100">
+                <div class="position-absolute top-0 start-0 end-0 bottom-0 h-100 w-100" style="margin-top: 10rem;">
+                    <div class="row row-cols-2">
+                        <div class="col-3 col-xl-2"></div>
+                        <div class="col-9 col-xl-10">
+                            <img src="../image/dummy-img-1920x900.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Vandore Heritage">
+                        </div>
+                    </div>
+                </div>
+                <div class="d-flex flex-column gap-5 justify-content-between scrollanimation animated fadeInLeft adr-7 h-100 padding-custom">
+                    <div class="d-flex flex-column gap-2 h-100">
+                        <div><h1 class="display" style="max-width: 700px;" data-i18n="blog" data-sb-field-path="heroHeading">Blogot</h1>
+                        <div class="row row-xl-cols-2 row-cols-1">
+                            <div class="col col-xl-2">
+                                <div class="d-flex flex-column gap-2 align-items-xl-center align-items-start">
+                                    <p data-i18n="stay_updated_with_the_latest_real_estate_trends_tips_and_market_insights" data-sb-field-path="heroSubheading">Palieciet atjaunināts ar jaunākajām nekustamā īpašuma tendencēm, padomiem un tirgus atziņām.
+                                    </p></div>
+                                    <div class="devider"></div>
+                                </div>
+                            </div>
+                            <div class="col col-xl-10"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Section Blog & News -->
+        <div class="section">
+            <div class="r-container d-flex flex-column gap-5">
+                <div class="row row-cols-xl-2 row-cols-1 align-items-end">
+                    <div class="col mb-3 scrollanimation animated fadeInLeft adr-7">
+                        <h3 style="max-width: 600px;" data-i18n="articles_related_to_aestetic_home_design">Raksti, kas saistīti ar estētisku mājas dizainu</h3>
+                    </div>
+                    <div class="col mb-3 scrollanimation animated fadeInDown adr-7">
+                        <div class="d-flex flex-column gap-2 align-items-end">
+                            <div class="w-max-content" style="justify-self: end;">
+                                <a href="blog.html" class="btn btn-accent-outline d-flex flex-row gap-2 justify-content-center">
+                                    <span data-i18n="browse_all_post">Pārlūkot visu pastu</span>
+                                    <i class="rtmicon rtmicon-arrow-up-right fw-bold"></i>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row row-cols-xl-2 row-cols-1" data-sb-field-path="blogPosts">
+                    <div class="col mb-3 scrollanimation animated fadeInLeft adr-7">
+                        <div class="card d-flex flex-column gap-4">
+                            <img src="../image/dummy-img-600x400.jpg" alt="Vandore Heritage" class="img-fluid" style="aspect-ratio: 5/3;">
+                            <a href="single_blog.html" data-sb-field-path="blogPosts[0].url#@href">
+                                <div class="d-flex flex-column gap-2">
+                                    <div class="d-flex flex-row gap-3">
+                                        <p class="m-0" data-i18n="jan_05_2025" data-sb-field-path="blogPosts[0].date">2025. gada 5. janvāris</p>
+                                        <p class="m-0" data-i18n="2_min_read">2 min Lasīt</p>
+                                    </div>
+                                    <h4 class="black-1 font-1" data-i18n="discover_unparalleled_expertise_in_market" data-sb-field-path="blogPosts[0].title">Atklājiet nepārspējamu kompetenci tirgū</h4>
+                                    <p data-i18n="discover_unparalleled_expertise_in_the_real_estate_market_providing_indepth_knowledge_strategic_insights_and_tailored_solutions_to_help_you_navigate_every_step_of_your_property_journey_with_confidence" data-sb-field-path="blogPosts[0].excerpt">
+                                        Atklājiet nepārspējamu kompetenci nekustamā īpašuma tirgū, nodrošinot padziļinātu 
+Zināšanas, stratēģiskas atziņas un pielāgoti risinājumi, kas palīdzēs jums orientēties katrā 
+Jūsu īpašuma ceļojuma solis ar pārliecību.
+                                    </p>
+                                </div>
+                            </a>
+                        </div>
+                    </div>
+                    <div class="col mb-3 scrollanimation animated fadeInLeft adr-7">
+                        <div class="card d-flex flex-column gap-4">
+                            <img src="../image/dummy-img-600x400.jpg" alt="Vandore Heritage" class="img-fluid" style="aspect-ratio: 5/3;">
+                            <a href="single_blog.html" data-sb-field-path="blogPosts[1].url#@href">
+                                <div class="d-flex flex-column gap-2">
+                                    <div class="d-flex flex-row gap-3">
+                                        <p class="m-0" data-i18n="jan_04_2025" data-sb-field-path="blogPosts[1].date">2025. gada 4. janvāris</p>
+                                        <p class="m-0" data-i18n="2_min_read">2 min Lasīt</p>
+                                    </div>
+                                    <h4 class="black-1 font-1" data-i18n="tips_for_choosing_house_paint_colors_to_look_elegant_and_comfortable" data-sb-field-path="blogPosts[1].title">Padomi, kā izvēlēties mājas krāsas krāsas, lai izskatās eleganti un ērti</h4>
+                                    <p data-i18n="discover_unparalleled_expertise_in_the_real_estate_market_providing_indepth_knowledge_strategic_insights_and_tailored_solutions_to_help_you_navigate_every_step_of_your_property_journey_with_confidence" data-sb-field-path="blogPosts[1].excerpt">
+                                        Atklājiet nepārspējamu kompetenci nekustamā īpašuma tirgū, nodrošinot padziļinātu 
+Zināšanas, stratēģiskas atziņas un pielāgoti risinājumi, kas palīdzēs jums orientēties katrā 
+Jūsu īpašuma ceļojuma solis ar pārliecību.
+                                    </p>
+                                </div>
+                            </a>
+                        </div>
+                    </div>
+                    <div class="col mb-3 scrollanimation animated fadeInRight adr-7">
+                        <div class="card d-flex flex-column gap-4">
+                            <img src="../image/dummy-img-600x400.jpg" alt="Vandore Heritage" class="img-fluid" style="aspect-ratio: 5/3;">
+                            <a href="single_blog.html" data-sb-field-path="blogPosts[2].url#@href">
+                                <div class="d-flex flex-column gap-2">
+                                    <div class="d-flex flex-row gap-3">
+                                        <p class="m-0" data-i18n="jan_03_2025" data-sb-field-path="blogPosts[2].date">2025. gada 3. janvāris</p>
+                                        <p class="m-0" data-i18n="3_min_read">3 minūtes Lasīt</p>
+                                    </div>
+                                    <h4 class="black-1 font-1" data-i18n="modern_and_functional_minimalist_home_design_inspirations" data-sb-field-path="blogPosts[2].title">Mūsdienīgas un funkcionālas minimālisma mājas dizaina iedvesmas</h4>
+                                    <p data-i18n="discover_unparalleled_expertise_in_the_real_estate_market_providing_indepth_knowledge_strategic_insights_and_tailored_solutions_to_help_you_navigate_every_step_of_your_property_journey_with_confidence" data-sb-field-path="blogPosts[2].excerpt">
+                                        Atklājiet nepārspējamu kompetenci nekustamā īpašuma tirgū, nodrošinot padziļinātu 
+Zināšanas, stratēģiskas atziņas un pielāgoti risinājumi, kas palīdzēs jums orientēties katrā 
+Jūsu īpašuma ceļojuma solis ar pārliecību.
+                                    </p>
+                                </div>
+                            </a>
+                        </div>
+                    </div>
+                    <div class="col mb-3 scrollanimation animated fadeInRight adr-7">
+                        <div class="card d-flex flex-column gap-4">
+                            <img src="../image/dummy-img-600x400.jpg" alt="Vandore Heritage" class="img-fluid" style="aspect-ratio: 5/3;">
+                            <a href="single_blog.html" data-sb-field-path="blogPosts[3].url#@href">
+                                <div class="d-flex flex-column gap-2">
+                                    <div class="d-flex flex-row gap-3">
+                                        <p class="m-0" data-i18n="jan_02_2025" data-sb-field-path="blogPosts[3].date">2025. gada 2. janvāris</p>
+                                        <p class="m-0" data-i18n="4_min_read">4 minūtes Lasīt</p>
+                                    </div>
+                                    <h4 class="black-1 font-1" data-i18n="common_home_design_mistakes_to_avoid_for_a_more_functional_living_space" data-sb-field-path="blogPosts[3].title">Parastās mājas dizaina kļūdas, lai izvairītos no funkcionālākas dzīves telpas</h4>
+                                    <p data-i18n="discover_unparalleled_expertise_in_the_real_estate_market_providing_indepth_knowledge_strategic_insights_and_tailored_solutions_to_help_you_navigate_every_step_of_your_property_journey_with_confidence" data-sb-field-path="blogPosts[3].excerpt">
+                                        Atklājiet nepārspējamu kompetenci nekustamā īpašuma tirgū, nodrošinot padziļinātu 
+Zināšanas, stratēģiskas atziņas un pielāgoti risinājumi, kas palīdzēs jums orientēties katrā 
+Jūsu īpašuma ceļojuma solis ar pārliecību.
+                                    </p>
+                                </div>
+                            </a>
+                        </div>
+                    </div>
+                    <div class="col mb-3 scrollanimation animated fadeInLeft adr-7">
+                        <div class="card d-flex flex-column gap-4">
+                            <img src="../image/dummy-img-600x400.jpg" alt="Vandore Heritage" class="img-fluid" style="aspect-ratio: 5/3;">
+                            <a href="single_blog.html" data-sb-field-path="blogPosts[4].url#@href">
+                                <div class="d-flex flex-column gap-2">
+                                    <div class="d-flex flex-row gap-3">
+                                        <p class="m-0" data-i18n="jan_01_2025" data-sb-field-path="blogPosts[4].date">2025. gada 1. janvāris</p>
+                                        <p class="m-0" data-i18n="2_min_read">2 min Lasīt</p>
+                                    </div>
+                                    <h4 class="black-1 font-1" data-i18n="how_to_create_a_cozy_outdoor_patio_for_relaxation_and_entertainment" data-sb-field-path="blogPosts[4].title">Kā izveidot mājīgu āra terasi atpūtai un izklaidei</h4>
+                                    <p data-i18n="discover_unparalleled_expertise_in_the_real_estate_market_providing_indepth_knowledge_strategic_insights_and_tailored_solutions_to_help_you_navigate_every_step_of_your_property_journey_with_confidence" data-sb-field-path="blogPosts[4].excerpt">
+                                        Atklājiet nepārspējamu kompetenci nekustamā īpašuma tirgū, nodrošinot padziļinātu 
+Zināšanas, stratēģiskas atziņas un pielāgoti risinājumi, kas palīdzēs jums orientēties katrā 
+Jūsu īpašuma ceļojuma solis ar pārliecību.
+                                    </p>
+                                </div>
+                            </a>
+                        </div>
+                    </div>
+                    <div class="col mb-3 scrollanimation animated fadeInLeft adr-7">
+                        <div class="card d-flex flex-column gap-4">
+                            <img src="../image/dummy-img-600x400.jpg" alt="Vandore Heritage" class="img-fluid" style="aspect-ratio: 5/3;">
+                            <a href="single_blog.html" data-sb-field-path="blogPosts[5].url#@href">
+                                <div class="d-flex flex-column gap-2">
+                                    <div class="d-flex flex-row gap-3">
+                                        <p class="m-0" data-i18n="dec_24_2024" data-sb-field-path="blogPosts[5].date">2024. gada 24. decembrī</p>
+                                        <p class="m-0" data-i18n="3_min_read">3 minūtes Lasīt</p>
+                                    </div>
+                                    <h4 class="black-1 font-1" data-i18n="the_benefits_of_sustainable_home_design_for_a_greener_future" data-sb-field-path="blogPosts[5].title">Ilgtspējīgas mājas dizaina priekšrocības zaļākai nākotnei</h4>
+                                    <p data-i18n="discover_unparalleled_expertise_in_the_real_estate_market_providing_indepth_knowledge_strategic_insights_and_tailored_solutions_to_help_you_navigate_every_step_of_your_property_journey_with_confidence" data-sb-field-path="blogPosts[5].excerpt">
+                                        Atklājiet nepārspējamu kompetenci nekustamā īpašuma tirgū, nodrošinot padziļinātu 
+Zināšanas, stratēģiskas atziņas un pielāgoti risinājumi, kas palīdzēs jums orientēties katrā 
+Jūsu īpašuma ceļojuma solis ar pārliecību.
+                                    </p>
+                                </div>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    </main>
+
+    <footer>
+        <div class="section position-relative bg-black-1" style="height: 90vh;">
+            <div class="row row-cols-xl-2 row-cols-1 h-100">
+                <div class="col col-xl-8 mb-3">
+                    <div class="d-flex flex-column gap-3 justify-content-between h-100">
+                        <div class="d-flex flex-column accent-primary">
+                            <p class="gray" data-i18n="get_contact">Sazināties</p>
+                            <h1 class="fw-normal" data-i18n="infovandoreheritagelv">info@vandoreheritage.lv</h1>
+                        </div>
+                        <img src="../image/logo-footer.png?v=2025" alt="Vandore Heritage" class="img-fluid" width="938">
+                    </div>
+                </div>
+                <div class="col col-xl-4 mb-3">
+                    <div class="d-flex flex-column gap-5 justify-content-between accent-primary h-100">
+                        <div class="d-flex flex-row gap-5">
+                            <ul class="list-unstyled d-flex flex-column gap-3 accent-color">
+                                <li>
+                                    <a href="index.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="home">
+                                        Mājas
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="about.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="about">
+                                        Pret
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="properties.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="properties">
+                                        Īpašības
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="rentals.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="rentals">
+                                        Īre
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="service.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="service">
+                                        Sakārtošana
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="contact.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="contact_us">
+                                        Sazinieties ar mums
+                                    </a>
+                                </li>
+                            </ul>
+                            <div class="d-flex flex-column gap-3">
+                                <a href="https://www.google.com/maps/place/Skanstes+iela+29A,+Vidzemes+priekšpilsēta,+Rīga,+LV-1013,+Latvia" class="link" target="_blank" data-i18n="skanstes_iela_29a91_rga_latvia">
+                                    Skanstes Iela 29A - 91, Rīga, Latvija
+                                </a>
+                                <a href="tel:+37129713030" class="link" data-i18n="371_29_71_3030">
+                                    +371 29 71 3030
+                                </a>
+                            </div>
+                        </div>
+                        <div class="d-flex flex-row gap-3">
+                            <div class="border-end pe-3 border-gray">
+                                <a href="" class="link d-flex flex-row gap-3 align-items-center" data-i18n="terms_conditions">
+                                    Noteikumi un nosacījumi
+                                </a>
+                            </div>
+                            <div>
+                                <a href="" class="link d-flex flex-row gap-3 align-items-center" data-i18n="privacy_notice">
+                                    Paziņojums par privātumu
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+
+    <!-- Back to top button -->
+    <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="rtmicon rtmicon-arrow-up"></i></a>
+
+    <!-- Scripts -->
+    <script src="../js/vendor/jquery.min.js"></script>
+    <script src="../js/vendor/bootstrap.bundle.min.js"></script>
+    <script src="../js/vendor/swiper-bundle.min.js"></script>
+    <script src="../js/script.js"></script>
+    <script src="../js/swiper-script.js"></script>
+    <script src="../js/submit-form.js"></script>
+    <script src="../js/vendor/isotope.pkgd.min.js"></script>
+    <script src="../js/video_embedded.js"></script>
+    <script src="../js/vendor/fslightbox.js"></script>
+    <script src="../js/custom.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.0/oyethemes_onscroll_animation.js"></script>
+
+
+
+</body></html>
+

--- a/_site/contact.html
+++ b/_site/contact.html
@@ -1,0 +1,503 @@
+<!DOCTYPE html><html lang="lv" data-sb-object-id="content/pages/contact.json"><head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;600&family=Noto+Serif:wght@700&display=swap&subset=latin-ext" rel="stylesheet">
+    <link rel="stylesheet" href="../css/style.css">
+    <link rel="stylesheet" href="../css/changes.css">
+    <link rel="stylesheet" href="../css/custom.css">
+    <link rel="stylesheet" href="../css/fonts.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.2/animation_utility.css">
+    <link rel="icon" type="image/x-icon" href="../image/red_LOGO_Vandore.png?v=2025">
+    <title data-i18n="vandore_heritage_contact_us" data-sb-field-path="title">Vandore Heritage - sazinieties ar mums</title>
+</head>
+
+<body>
+    <!-- Header -->
+    <header class="bg-accent-primary px-5">
+        <nav class="navbar">
+            <div class="container-fluid ps-3 gap-3">
+                <div class="me-auto"></div>
+                <div class="logo-container position-absolute start-50 translate-middle-x" style="margin-top: 2cm;">
+                    <a class="navbar-brand" href="index.html"><img src="../image/red_LOGO_Vandore.png?v=2025" alt="Vandore Heritage" class="img-fluid"></a>
+                </div>
+                <div class="w-max-content" style="margin-top: 0.5cm;">
+                    <button class="btn btn-toggler-accent" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDark" aria-controls="offcanvasDark"><i class="fa-solid fa-bars"></i>
+                        Menu</button>
+
+                    <div class="offcanvas offcanvas-end offcanvas-fullwidth text-bg-dark" tabindex="-1" id="offcanvasDark" aria-labelledby="offcanvasRightLabel">
+                        <div class="offcanvas-header bg-transparent">
+                            <h5 id="offcanvasRightLabel">Menu</h5>
+                            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+                        </div>
+                        <div class="offcanvas-body">
+                            <div class="r-container">
+                                <div class="row row-cols-xl-2 row-cols-1">
+                                    <div class="col col-xl-10 mb-3">
+                                        <div class="d-flex flex-column">
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="01_homepage">01. MÄjas lapa</span>
+                                                <img src="../image/img6.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="index.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="02_properties">02. ÄªpaÅ¡umi</span>
+                                                <img src="../image/img5.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="properties.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="03_short_form_rentals">03. Äªsas formas Ä«re</span>
+                                                <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="rentals.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="04_about_us">04. Par mums</span>
+                                                <img src="../image/img33.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="about.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="05_services">05. Pakalpojumi</span>
+                                                <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="service.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="06_contact">06. Sazinieties</span>
+                                                <img src="../image/img29.png" class="img-fluid rounded-3 " style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="contact.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="07_news">07. Jaunumi</span>
+                                                <img src="../image/img26.png" class="img-fluid rounded-3 " style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="blog.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col col-xl-2 mb-3">
+                                        <div class="d-flex flex-column gap-5 accent-primary text-end">
+                                           <div class="d-flex flex-column gap-4">
+                                                <h6 data-i18n="riga_latvia">RÄ«ga, Latvija</h6>
+                                                <div class="d-flex flex-column gap-3">
+                                                    <span data-i18n="skanstes_iela_29a91_rga_latvia">
+                                                        Skanstes Iela 29A - 91, RÄ«ga, Latvija
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </nav>
+    </header>
+    <!-- End Header -->
+
+    <!-- Main -->
+    <main>
+        <!-- Banner -->
+        <div class="section position-relative bg-attach-cover">
+            <div class="r-container position-relative h-100">
+                <div class="position-absolute top-0 start-0 end-0 bottom-0 h-100 w-100" style="margin-top: 10rem;">
+                    <div class="row row-cols-2">
+                        <div class="col-3 col-xl-2"></div>
+                        <div class="col-9 col-xl-10">
+                            <img src="../image/dummy-img-1920x900.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Vandore Heritage">
+                        </div>
+                    </div>
+                </div>
+                <div class="d-flex flex-column gap-5 justify-content-between scrollanimation animated fadeInLeft adr-7 h-100 padding-custom">
+                    <div class="d-flex flex-column gap-2 h-100">
+                        <div><h1 class="display" style="max-width: 700px;" data-i18n="contact_us" data-sb-field-path="heroHeading">Sazinieties ar mums</h1>
+                        <div class="row row-xl-cols-2 row-cols-1">
+                            <div class="col col-xl-2">
+                                <div class="d-flex flex-column gap-2 align-items-xl-center align-items-start">
+                                    <p data-i18n="get_in_touch_with_us_for_personalized_real_estate_advice_and_services" data-sb-field-path="heroSubheading">Sazinieties ar mums, lai saÅ†emtu personalizÄ“tus padomus par nekustamo Ä«paÅ¡umu un pakalpojumiem.
+                                    </p></div>
+                                    <div class="devider"></div>
+                                </div>
+                            </div>
+                            <div class="col col-xl-10"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Section Contact Us -->
+        <div class="section">
+            <div class="r-container">
+                <div class="row row-cols-xl-2 row-cols-1" data-sb-field-path="sections">
+                    <div class="col scrollanimation animated fadeInLeft">
+                        <div class="d-flex flex-column gap-5 h-100 p-5 border border-gray-hover rounded-2">
+                            <div class="d-flex flex-column gap-3">
+                                <h3 data-i18n="get_in_touch_with_us_today" data-sb-field-path="sections[0].heading">Sazinieties ar mums Å¡odien</h3>
+                                <p data-i18n="have_questions_contact_rofaria_today_for_expert_assistance_with_all_your_real_estate_needs_were_here_to_help" data-sb-field-path="sections[0].text">
+                                    Ir jautÄjumi? Sazinieties ar Rofaria Å¡odien, lai saÅ†emtu ekspertu palÄ«dzÄ«bu ar visu savu reÄlo 
+ÄªpaÅ¡uma vajadzÄ«bÄm. MÄ“s esam Å¡eit, lai palÄ«dzÄ“tu!
+                                </p>
+                            </div>
+                            <div class="d-flex flex-column gap-3">
+                                <a href="tel:+37129713030" class="link" data-i18n="roberts_punka_371_29_71_3030">
+                                    Roberts Punka - +371 29 71 3030
+                                </a>
+                                <a href="tel:+37129197047" class="link" data-i18n="dolfs_mrti_krauklis_371_29_19_7047">
+                                    Ä€dolfs MÄrtiÅ†Å¡ Krauklis - +371 29 19 7047
+                                </a>
+                                <a href="mailto:info@vandoreheritage.lv" class="link" data-i18n="infovandoreheritagelv">
+                                    info@vandoreheritage.lv
+                                </a>
+                                <a href="https://www.google.com/maps/place/Skanstes+iela+29A,+Vidzemes+priekÅ¡pilsÄ“ta,+RÄ«ga,+LV-1013,+Latvia" class="link" target="_blank" data-i18n="skanstes_iela_29a91_rga_latvia">
+                                    Skanstes Iela 29A - 91, RÄ«ga, Latvija
+                                </a>
+                            </div>
+                            <div class="social-container mb-5 gap-3">
+                                <a href="https://www.facebook.com/share/1AwoA2Vb1U/?mibextid=wwXIfr" class="social-item-2" target="_blank">
+                                    <i class="fa-brands fa-xs fa-facebook-f"></i>
+                                </a>
+                                <a href="https://www.instagram.com/vandoreheritage" class="social-item-2" target="_blank">
+                                    <i class="fa-brands fa-xs fa-instagram"></i>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col scrollanimation animated fadeInRight">
+                        <div class="d-flex flex-column gap-3">
+                            <div class="d-flex flex-column gap-3 w-100 p-5 bg-gray-hover rounded-2">
+                                <div class="success_msg toast align-items-center w-100 shadow-none mb-3 border border-success rounded-pill my-4" role="alert" aria-live="assertive" aria-atomic="true">
+                                    <div class="d-flex p-2">
+                                        <div class="toast-body f-18 d-flex flex-row gap-3 align-items-center text-success">
+                                            <i class="fa-solid fa-check f-36 text-success"></i>
+                                            Your Message Successfully Send.
+                                        </div>
+                                        <button type="button" class="me-2 m-auto bg-transparent border-0 ps-1 pe-0 text-success" data-bs-dismiss="toast" aria-label="Close"><i class="fa-solid fa-xmark"></i></button>
+                                    </div>
+                                </div>
+                                <div class="error_msg toast align-items-center w-100 shadow-none border-danger mb-3 my-4 border rounded-pill" role="alert" aria-live="assertive" aria-atomic="true">
+                                    <div class="d-flex p-2">
+                                        <div class="toast-body f-18 d-flex flex-row gap-3 align-items-center text-danger">
+                                            <i class="fa-solid fa-triangle-exclamation f-36 text-danger"></i>
+                                            Something Wrong ! Send Form Failed.
+                                        </div>
+                                        <button type="button" class="me-2 m-auto bg-transparent border-0 ps-1 pe-0 text-danger" data-bs-dismiss="toast" aria-label="Close"><i class="fa-solid fa-xmark"></i></button>
+                                    </div>
+                                </div>
+                                <form class="d-flex flex-column gap-1 h-100 justify-content-center w-100 needs-validation form" novalidate="">
+                                    <div class="mb-3">
+                                        <label for="name" class="form-label">Name<span class="accent-color">*</span></label>
+                                        <input type="text" class="form-control py-3 px-4" name="name" id="name" placeholder="Jūsu pilnais vārds" required="">
+                                        <div class="invalid-feedback" data-i18n="the_field_is_required">
+                                            Lauks ir nepiecieÅ¡ams.
+                                        </div>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label for="email" class="form-label">E-mail<span class="accent-color">*</span></label>
+                                        <input type="email" class="form-control py-3 px-4" name="email" id="email" placeholder="Jūsu e-pasts" required="">
+                                        <div class="invalid-feedback" data-i18n="the_field_is_required">
+                                            Lauks ir nepiecieÅ¡ams.
+                                        </div>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label for="message" class="form-label">Message<span class="accent-color">*</span></label>
+                                        <textarea class="form-control py-3 px-4" id="message" name="message" rows="4" placeholder="Jūsu ziņojums" required=""></textarea>
+                                        <div class="invalid-feedback" data-i18n="the_field_is_required">
+                                            Lauks ir nepieciešams.
+                                        </div>
+                                    </div>
+                                    <div>
+                                        <button type="submit" class="btn btn-accent submit_form d-flex flex-row gap-2 justify-content-center gap-3">
+                                            <span data-i18n="send_message">NosÅ«tÄ«t ziÅ†ojumu</span>
+                                            <i class="rtmicon rtmicon-arrow-up-right fw-bold"></i>
+                                        </button>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="section">
+            <div class="r-container">
+                <div class="position-relative h-100">
+                    <iframe loading="lazy" class="maps" src="https://maps.google.com/maps?q=London%20Eye%2C%20London%2C%20United%20Kingdom&amp;t=m&amp;z=14&amp;output=embed&amp;iwloc=near" title="London Eye, London, United Kingdom" aria-label="London Eye, London, United Kingdom"></iframe>
+                </div>
+            </div>
+        </div>
+
+        <!-- Section FAQs -->
+        <div class="section">
+            <div class="r-container d-flex flex-column gap-3">
+                <div class="row row-cols-xl-2 row-cols-1">
+                    <div class="col mb-3 scrollanimation animated fadeInLeft adr-7">
+                        <div class="d-flex flex-column gap-5">
+                            <h3 style="max-width: 400px;" data-i18n="client_support_questions">Klienta atbalsta jautÄjumi</h3>
+                        </div>
+                    </div>
+                    <div class="col mb-3  scrollanimation animated fadeInDown adr-7">
+                        <div class="w-max-content" style="justify-self: end;">
+                            <a href="faq.html" class="btn btn-accent d-flex flex-row gap-2 justify-content-center">
+                                <span data-i18n="still_have_question">JoprojÄm ir jautÄjums?</span>
+                                <i class="rtmicon rtmicon-arrow-up-right fw-bold"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <div class="row row-cols-xl-2 row-cols-1 scrollanimation animated fadeInRight adr-7">
+                    <div class="col mb-3">
+                        <div class="d-flex flex-column gap-4 w-100">
+                            <div class="accordion mt-3 d-flex flex-column gap-4" id="faqAccordionContact1">
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#faqContact1" aria-expanded="true" aria-controls="faqContact1" data-i18n="do_you_only_work_with_luxury_properties">
+                                            Vai jÅ«s strÄdÄjat tikai ar luksusa Ä«paÅ¡umiem?
+                                        </button>
+                                    </h2>
+                                    <div id="faqContact1" class="accordion-collapse collapse show" data-bs-parent="#faqAccordionContact1">
+                                        <div class="accordion-body" data-i18n="partly_focus_is_on_exclusive_properties_but_also_on_projects_with_potential">
+                                            DaÄ¼Ä“ji. KoncentrÄ“Å¡anÄs ir uz ekskluzÄ«viem Ä«paÅ¡umiem, bet arÄ« uz projektiem ar potenciÄlu.
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faqContact2" aria-expanded="false" aria-controls="faqContact2" data-i18n="what_makes_you_different_from_other_agencies">
+                                            Kas padara jÅ«s atÅ¡Ä·irÄ«gu no citÄm aÄ£entÅ«rÄm?
+                                        </button>
+                                    </h2>
+                                    <div id="faqContact2" class="accordion-collapse collapse" data-bs-parent="#faqAccordionContact1">
+                                        <div class="accordion-body" data-i18n="fullservice_adaptable_detailed_combining_sales_rentals_renovation_design_and_legal_support">
+                                            Pilna servisa, pielÄgojama, detalizÄ“ta, pÄrdoÅ¡anas, Ä«res, atjaunoÅ¡anas, dizaina un juridiskÄ atbalsta apvienoÅ¡ana.
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faqContact3" aria-expanded="false" aria-controls="faqContact3" data-i18n="how_fast_can_you_put_a_property_on_the_market">
+                                            Cik Ätri jÅ«s varat ievietot nekustamo Ä«paÅ¡umu tirgÅ«?
+                                        </button>
+                                    </h2>
+                                    <div id="faqContact3" class="accordion-collapse collapse" data-bs-parent="#faqAccordionContact1">
+                                        <div class="accordion-body" data-i18n="publication_is_fast_but_most_time_goes_into_market_analysis_and_precise_pricing">
+                                            PublikÄcija ir Ätra, bet lielÄkÄ daÄ¼a laika tiek veikta tirgus analÄ«zÄ“ un precÄ«zas cenÄs.
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faqContact4" aria-expanded="false" aria-controls="faqContact4" data-i18n="how_do_you_prepare_a_property_for_salerent">
+                                            KÄ jÅ«s sagatavojat Ä«paÅ¡umu pÄrdoÅ¡anai/Ä«rei?
+                                        </button>
+                                    </h2>
+                                    <div id="faqContact4" class="accordion-collapse collapse" data-bs-parent="#faqAccordionContact1">
+                                        <div class="accordion-body" data-i18n="evaluation_strategy_improvements_cleaning_styling_professional_photosvideo">
+                                            NovÄ“rtÄ“Å¡ana â†’ StratÄ“Ä£ija â†’ Uzlabojumi â†’ TÄ«rÄ«Å¡ana â†’ Stils â†’ ProfesionÄli fotoattÄ“li/video.
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faqContact5" aria-expanded="false" aria-controls="faqContact5" data-i18n="how_do_you_set_the_best_price">
+                                            KÄ jÅ«s iestatÄt labÄko cenu?
+                                        </button>
+                                    </h2>
+                                    <div id="faqContact5" class="accordion-collapse collapse" data-bs-parent="#faqAccordionContact1">
+                                        <div class="accordion-body" data-i18n="market_research_property_potential_client_goals_plus_independent_valuers_if_needed">
+                                            Tirgus izpÄ“te, Ä«paÅ¡uma potenciÄls, klienta mÄ“rÄ·i, kÄ arÄ« neatkarÄ«gi vÄ“rtÄ“tÄji, ja nepiecieÅ¡ams.
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col mb-3">
+                        <div class="d-flex flex-column gap-4 w-100">
+                            <div class="accordion mt-3 d-flex flex-column gap-4" id="faqAccordionContact2">
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faqContact6" aria-expanded="true" aria-controls="faqContact6" data-i18n="how_is_commission_determined">
+                                            KÄ tiek noteikta komisija?
+                                        </button>
+                                    </h2>
+                                    <div id="faqContact6" class="accordion-collapse collapse" data-bs-parent="#faqAccordionContact2">
+                                        <div class="accordion-body" data-i18n="based_on_scope_of_service_and_contract_type_exclusive_or_not">
+                                            Pamatojoties uz pakalpojumu un lÄ«guma veida apjomu (ekskluzÄ«vs vai nÄ“).
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faqContact7" aria-expanded="false" aria-controls="faqContact7" data-i18n="do_you_manage_shortterm_rentals">
+                                            Vai jÅ«s pÄrvaldÄt Ä«stermiÅ†a Ä«ri?
+                                        </button>
+                                    </h2>
+                                    <div id="faqContact7" class="accordion-collapse collapse" data-bs-parent="#faqAccordionContact2">
+                                        <div class="accordion-body" data-i18n="yes_full_management_setup_content_listings_pricing_guest_communication_maintenance">
+                                            JÄ, pilna pÄrvaldÄ«ba: iestatÄ«Å¡ana, saturs, saraksti, cenu noteikÅ¡ana, viesu komunikÄcija, uzturÄ“Å¡ana.
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faqContact8" aria-expanded="false" aria-controls="faqContact8" data-i18n="why_use_an_agent">
+                                            KÄpÄ“c izmantot aÄ£entu?
+                                        </button>
+                                    </h2>
+                                    <div id="faqContact8" class="accordion-collapse collapse" data-bs-parent="#faqAccordionContact2">
+                                        <div class="accordion-body" data-i18n="to_avoid_mistakes_maximize_property_potential_get_strategy_quality_presentation_communication_legal_order_and_peace_of_mind">
+                                            Lai izvairÄ«tos no kÄ¼Å«dÄm, maksimÄli palieliniet Ä«paÅ¡uma potenciÄlu, iegÅ«stiet stratÄ“Ä£iju, kvalitatÄ«vu prezentÄciju, komunikÄciju, juridisko kÄrtÄ«bu un mieru.
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faqContact9" aria-expanded="false" aria-controls="faqContact9" data-i18n="how_do_you_prepare_a_property_for_salerent">
+                                            KÄ jÅ«s sagatavojat Ä«paÅ¡umu pÄrdoÅ¡anai/Ä«rei?
+                                        </button>
+                                    </h2>
+                                    <div id="faqContact9" class="accordion-collapse collapse" data-bs-parent="#faqAccordionContact2">
+                                        <div class="accordion-body" data-i18n="evaluation_strategy_improvements_cleaning_styling_professional_photosvideo">
+                                            NovÄ“rtÄ“Å¡ana â†’ StratÄ“Ä£ija â†’ Uzlabojumi â†’ TÄ«rÄ«Å¡ana â†’ Stils â†’ ProfesionÄli fotoattÄ“li/video.
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#faqContact10" aria-expanded="true" aria-controls="faqContact10" data-i18n="what_makes_you_different_from_other_agencies">
+                                            Kas padara jÅ«s atÅ¡Ä·irÄ«gu no citÄm aÄ£entÅ«rÄm?
+                                        </button>
+                                    </h2>
+                                    <div id="faqContact10" class="accordion-collapse collapse show" data-bs-parent="#faqAccordionContact2">
+                                        <div class="accordion-body" data-i18n="fullservice_adaptable_detailed_combining_sales_rentals_renovation_design_and_legal_support">
+                                            Pilna servisa, pielÄgojama, detalizÄ“ta, pÄrdoÅ¡anas, Ä«res, atjaunoÅ¡anas, dizaina un juridiskÄ atbalsta apvienoÅ¡ana.
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    </main>
+
+    <footer>
+        <div class="section position-relative bg-black-1" style="height: 90vh;">
+            <div class="row row-cols-xl-2 row-cols-1 h-100">
+                <div class="col col-xl-8 mb-3">
+                    <div class="d-flex flex-column gap-3 justify-content-between h-100">
+                        <div class="d-flex flex-column accent-primary">
+                            <p class="gray" data-i18n="get_contact">SazinÄties</p>
+                            <h1 class="fw-normal" data-i18n="infovandoreheritagelv">info@vandoreheritage.lv</h1>
+                        </div>
+                        <img src="../image/logo-footer.png?v=2025" alt="Vandore Heritage" class="img-fluid" width="938">
+                    </div>
+                </div>
+                <div class="col col-xl-4 mb-3">
+                    <div class="d-flex flex-column gap-5 justify-content-between accent-primary h-100">
+                        <div class="d-flex flex-row gap-5">
+                            <ul class="list-unstyled d-flex flex-column gap-3 accent-color">
+                                <li>
+                                    <a href="index.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="home">
+                                        MÄjas
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="about.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="about">
+                                        Pret
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="properties.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="properties">
+                                        ÄªpaÅ¡Ä«bas
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="rentals.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="rentals">
+                                        Äªre
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="service.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="service">
+                                        SakÄrtoÅ¡ana
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="contact.html" class="link active d-flex flex-row gap-3 align-items-center" data-i18n="contact_us">
+                                        Sazinieties ar mums
+                                    </a>
+                                </li>
+                            </ul>
+                            <div class="d-flex flex-column gap-3">
+                                <a href="https://www.google.com/maps/place/Skanstes+iela+29A,+Vidzemes+priekÅ¡pilsÄ“ta,+RÄ«ga,+LV-1013,+Latvia" class="link" target="_blank" data-i18n="skanstes_iela_29a91_rga_latvia">
+                                    Skanstes Iela 29A - 91, RÄ«ga, Latvija
+                                </a>
+                                <a href="tel:+37129713030" class="link" data-i18n="371_29_71_3030">
+                                    +371 29 71 3030
+                                </a>
+                            </div>
+                        </div>
+                        <div class="d-flex flex-row gap-3">
+                            <div class="border-end pe-3 border-gray">
+                                <a href="" class="link d-flex flex-row gap-3 align-items-center" data-i18n="terms_conditions">
+                                    Noteikumi un nosacÄ«jumi
+                                </a>
+                            </div>
+                            <div>
+                                <a href="" class="link d-flex flex-row gap-3 align-items-center" data-i18n="privacy_notice">
+                                    PaziÅ†ojums par privÄtumu
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+
+    <!-- Back to top button -->
+    <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="rtmicon rtmicon-arrow-up"></i></a>
+
+    <!-- Scripts -->
+    <script src="../js/vendor/jquery.min.js"></script>
+    <script src="../js/vendor/bootstrap.bundle.min.js"></script>
+    <script src="../js/vendor/swiper-bundle.min.js"></script>
+    <script src="../js/script.js"></script>
+    <script src="../js/swiper-script.js"></script>
+    <script src="../js/submit-form.js"></script>
+    <script src="../js/vendor/isotope.pkgd.min.js"></script>
+    <script src="../js/video_embedded.js"></script>
+    <script src="../js/vendor/fslightbox.js"></script>
+    <script src="../js/custom.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.0/oyethemes_onscroll_animation.js"></script>
+
+
+
+</body></html>
+

--- a/_site/faq.html
+++ b/_site/faq.html
@@ -1,0 +1,441 @@
+<!DOCTYPE html><html lang="lv" data-sb-object-id="content/pages/faq.json"><head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;600&family=Noto+Serif:wght@700&display=swap&subset=latin-ext" rel="stylesheet">
+    <link rel="stylesheet" href="../css/style.css">
+    <link rel="stylesheet" href="../css/changes.css">
+    <link rel="stylesheet" href="../css/custom.css">
+    <link rel="stylesheet" href="../css/fonts.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.2/animation_utility.css">
+    <link rel="icon" type="image/x-icon" href="../image/red_LOGO_Vandore.png?v=2025">
+    <title data-i18n="vandore_heritage_faqs" data-sb-field-path="title">Vandore Heritage - FAQ</title>
+</head>
+
+<body>
+    <!-- Header -->
+    <header class="bg-accent-primary px-5">
+        <nav class="navbar">
+            <div class="container-fluid ps-3 gap-3">
+                <div class="me-auto"></div>
+                <div class="logo-container position-absolute start-50 translate-middle-x" style="margin-top: 2cm;">
+                    <a class="navbar-brand" href="index.html"><img src="../image/red_LOGO_Vandore.png?v=2025" alt="Vandore Heritage" class="img-fluid"></a>
+                </div>
+                <div class="w-max-content" style="margin-top: 0.5cm;">
+                    <button class="btn btn-toggler-accent" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDark" aria-controls="offcanvasDark"><i class="fa-solid fa-bars"></i>
+                        Menu</button>
+
+                    <div class="offcanvas offcanvas-end offcanvas-fullwidth text-bg-dark" tabindex="-1" id="offcanvasDark" aria-labelledby="offcanvasRightLabel">
+                        <div class="offcanvas-header bg-transparent">
+                            <h5 id="offcanvasRightLabel">Menu</h5>
+                            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+                        </div>
+                        <div class="offcanvas-body">
+                            <div class="r-container">
+                                <div class="row row-cols-xl-2 row-cols-1">
+                                    <div class="col col-xl-10 mb-3">
+                                        <div class="d-flex flex-column">
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="01_homepage">01. Mājas lapa</span>
+                                                <img src="../image/img6.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="index.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="02_properties">02. Īpašumi</span>
+                                                <img src="../image/img5.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="properties.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="03_short_form_rentals">03. Īsas formas īre</span>
+                                                <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="rentals.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="04_about_us">04. Par mums</span>
+                                                <img src="../image/img33.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="about.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="05_services">05. Pakalpojumi</span>
+                                                <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="service.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="06_contact">06. Sazinieties</span>
+                                                <img src="../image/img29.png" class="img-fluid rounded-3 " style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="contact.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="07_news">07. Jaunumi</span>
+                                                <img src="../image/img26.png" class="img-fluid rounded-3 " style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="blog.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col col-xl-2 mb-3">
+                                        <div class="d-flex flex-column gap-5 accent-primary text-end">
+                                            <div class="d-flex flex-column gap-4">
+                                                <h6 data-i18n="pekanbaru_ina">Pekanbaru, Ina</h6>
+                                                <div class="d-flex flex-column gap-3">
+                                                    <span data-i18n="99_roving_st">
+                                                        99 Roving st.,
+                                                    </span>
+                                                    <span data-i18n="big_city_pku">
+                                                        Liela pilsēta, PKU
+                                                    </span>
+                                                    <span data-i18n="13245">
+                                                        13245
+                                                    </span>
+                                                </div>
+                                            </div>
+                                            <div class="d-flex flex-column gap-4">
+                                                <h6 data-i18n="new_york_usa">Ņujorka, ASV</h6>
+                                                <div class="d-flex flex-column gap-3">
+                                                    <span data-i18n="99_roving_st">
+                                                        99 Roving st.,
+                                                    </span>
+                                                    <span data-i18n="mega_city_nyc">
+                                                        Mega City, NYC
+                                                    </span>
+                                                    <span data-i18n="13245">
+                                                        13245
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </nav>
+    </header>
+    <!-- End Header -->
+
+    <!-- Main -->
+    <main>
+        <!-- Banner -->
+        <div class="section position-relative bg-attach-cover">
+            <div class="r-container position-relative h-100">
+                <div class="position-absolute top-0 start-0 end-0 bottom-0 h-100 w-100" style="margin-top: 10rem;">
+                    <div class="row row-cols-2">
+                        <div class="col-3 col-xl-2"></div>
+                        <div class="col-9 col-xl-10">
+                            <img src="../image/dummy-img-1920x900.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Vandore Heritage">
+                        </div>
+                    </div>
+                </div>
+                <div class="d-flex flex-column gap-5 justify-content-between scrollanimation animated fadeInLeft adr-7 h-100 padding-custom">
+                    <div class="d-flex flex-column gap-2 h-100">
+                        <div><h1 class="display" style="max-width: 700px;" data-i18n="faqs" data-sb-field-path="heroHeading">FAQ</h1>
+                        <div class="row row-xl-cols-2 row-cols-1">
+                            <div class="col col-xl-2">
+                                <div class="d-flex flex-column gap-2 align-items-xl-center align-items-start">
+                                    <p data-i18n="discover_a_diverse_range_of_properties_from_residential_to_commercial_tailored_to_suit_your_preferences" data-sb-field-path="heroSubheading">Atklājiet daudzveidīgu īpašumu klāstu, sākot no dzīvojamās līdz komerciālai, pielāgota 
+atbilst jūsu vēlmēm.
+                                    </p></div>
+                                    <div class="devider"></div>
+                                </div>
+                            </div>
+                            <div class="col col-xl-10"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Section FAQs -->
+        <div class="section">
+            <div class="r-container d-flex flex-column gap-3">
+                <div class="row row-cols-xl-2 row-cols-1">
+                    <div class="col mb-3 scrollanimation animated fadeInLeft adr-7">
+                        <div class="d-flex flex-column gap-5">
+                            <h3 style="max-width: 400px;" data-i18n="client_support_questions">Klienta atbalsta jautājumi</h3>
+                        </div>
+                    </div>
+                    <div class="col mb-3  scrollanimation animated fadeInDown adr-7">
+                        <div class="w-max-content" style="justify-self: end;">
+                            <a href="faq.html" class="btn btn-accent d-flex flex-row gap-2 justify-content-center">
+                                <span data-i18n="still_have_question">Joprojām ir jautājums?</span>
+                                <i class="rtmicon rtmicon-arrow-up-right fw-bold"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <div class="row row-cols-xl-2 row-cols-1 scrollanimation animated fadeInRight adr-7" data-sb-field-path="faqs">
+                    <div class="col mb-3">
+                        <div class="d-flex flex-column gap-4 w-100">
+                            <div class="accordion mt-3 d-flex flex-column gap-4" id="faqAccordion1">
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#faq1" aria-expanded="true" aria-controls="faq1" data-i18n="how_can_i_start_searching_for_properties_on_this_website" data-sb-field-path="faqs[0].question">
+                                            Kā es varu sākt meklēt īpašumus šajā vietnē?
+                                        </button>
+                                    </h2>
+                                    <div id="faq1" class="accordion-collapse collapse show" data-bs-parent="#faqAccordion1">
+                                        <div class="accordion-body" data-i18n="simply_use_the_search_feature_on_the_homepage_to_filter_properties_by_location_price_number_of_rooms_and_more_for_personalized_recommendations_or_further_assistance_feel_free_to_contact_our_team" data-sb-field-path="faqs[0].answer">
+                                            Vienkārši izmantojiet meklēšanas funkciju mājas lapā, lai filtrētu rekvizītus pēc 
+Atrašanās vieta, cena, istabu skaits un daudz kas cits. Personalizētiem ieteikumiem 
+Vai arī turpmāka palīdzība, sazinieties ar mūsu komandu.
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq2" aria-expanded="false" aria-controls="faq2" data-i18n="are_properties_available_in_different_price_ranges" data-sb-field-path="faqs[1].question">
+                                            Vai īpašumi ir pieejami dažādos cenu diapazonos?
+                                        </button>
+                                    </h2>
+                                    <div id="faq2" class="accordion-collapse collapse" data-bs-parent="#faqAccordion1">
+                                        <div class="accordion-body" data-i18n="lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_donec_vel_erat_nibh_sed_rutrum_turpis_quis_lacinia_sollicitudin_sed_ac_neque_cursus_ornare_augue_pellentesque_elementum_turpis" data-sb-field-path="faqs[1].answer">
+                                            Lorem ipsum dolor sēž amet, consectetur adipiscing elit. Donec vel erat 
+nibh. Sed Rutrum Turpis quis lacinia solicitudin. Sed ac neque cursus, 
+Ornare Augue grilentesque, Elementum Turpis.
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq3" aria-expanded="false" aria-controls="faq3" data-i18n="can_i_sell_my_property_through_rofaria" data-sb-field-path="faqs[2].question">
+                                            Vai es varu pārdot savu īpašumu caur Rofaria?
+                                        </button>
+                                    </h2>
+                                    <div id="faq3" class="accordion-collapse collapse" data-bs-parent="#faqAccordion1">
+                                        <div class="accordion-body" data-i18n="lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_donec_vel_erat_nibh_sed_rutrum_turpis_quis_lacinia_sollicitudin_sed_ac_neque_cursus_ornare_augue_pellentesque_elementum_turpis" data-sb-field-path="faqs[2].answer">
+                                            Lorem ipsum dolor sēž amet, consectetur adipiscing elit. Donec vel erat 
+nibh. Sed Rutrum Turpis quis lacinia solicitudin. Sed ac neque cursus, 
+Ornare Augue grilentesque, Elementum Turpis.
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq4" aria-expanded="false" aria-controls="faq4" data-i18n="is_there_a_fee_for_the_initial_consultation" data-sb-field-path="faqs[3].question">
+                                            Vai par sākotnējo konsultāciju ir jāmaksā?
+                                        </button>
+                                    </h2>
+                                    <div id="faq4" class="accordion-collapse collapse" data-bs-parent="#faqAccordion1">
+                                        <div class="accordion-body" data-i18n="lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_donec_vel_erat_nibh_sed_rutrum_turpis_quis_lacinia_sollicitudin_sed_ac_neque_cursus_ornare_augue_pellentesque_elementum_turpis" data-sb-field-path="faqs[3].answer">
+                                            Lorem ipsum dolor sēž amet, consectetur adipiscing elit. Donec vel erat 
+nibh. Sed Rutrum Turpis quis lacinia solicitudin. Sed ac neque cursus, 
+Ornare Augue grilentesque, Elementum Turpis.
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq5" aria-expanded="false" aria-controls="faq5" data-i18n="what_main_services_does_rofaria_offer" data-sb-field-path="faqs[4].question">
+                                            Kādus galvenos pakalpojumus piedāvā Rofaria?
+                                        </button>
+                                    </h2>
+                                    <div id="faq5" class="accordion-collapse collapse" data-bs-parent="#faqAccordion1">
+                                        <div class="accordion-body" data-i18n="lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_donec_vel_erat_nibh_sed_rutrum_turpis_quis_lacinia_sollicitudin_sed_ac_neque_cursus_ornare_augue_pellentesque_elementum_turpis" data-sb-field-path="faqs[4].answer">
+                                            Lorem ipsum dolor sēž amet, consectetur adipiscing elit. Donec vel erat 
+nibh. Sed Rutrum Turpis quis lacinia solicitudin. Sed ac neque cursus, 
+Ornare Augue grilentesque, Elementum Turpis.
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col mb-3">
+                        <div class="d-flex flex-column gap-4 w-100">
+                            <div class="accordion mt-3 d-flex flex-column gap-4" id="faqAccordion2">
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq6" aria-expanded="false" aria-controls="faq6" data-i18n="is_there_a_fee_for_the_initial_consultation" data-sb-field-path="faqs[5].question">
+                                            Vai par sākotnējo konsultāciju ir jāmaksā?
+                                        </button>
+                                    </h2>
+                                    <div id="faq6" class="accordion-collapse collapse" data-bs-parent="#faqAccordion2">
+                                        <div class="accordion-body" data-i18n="lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_donec_vel_erat_nibh_sed_rutrum_turpis_quis_lacinia_sollicitudin_sed_ac_neque_cursus_ornare_augue_pellentesque_elementum_turpis" data-sb-field-path="faqs[5].answer">
+                                            Lorem ipsum dolor sēž amet, consectetur adipiscing elit. Donec vel erat 
+nibh. Sed Rutrum Turpis quis lacinia solicitudin. Sed ac neque cursus, 
+Ornare Augue grilentesque, Elementum Turpis.
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq7" aria-expanded="true" aria-controls="faq7" data-i18n="what_main_services_does_rofaria_offer" data-sb-field-path="faqs[6].question">
+                                            Kādus galvenos pakalpojumus piedāvā Rofaria?
+                                        </button>
+                                    </h2>
+                                    <div id="faq7" class="accordion-collapse collapse" data-bs-parent="#faqAccordion2">
+                                        <div class="accordion-body" data-i18n="lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_donec_vel_erat_nibh_sed_rutrum_turpis_quis_lacinia_sollicitudin_sed_ac_neque_cursus_ornare_augue_pellentesque_elementum_turpis" data-sb-field-path="faqs[6].answer">
+                                            Lorem ipsum dolor sēž amet, consectetur adipiscing elit. Donec vel erat 
+nibh. Sed Rutrum Turpis quis lacinia solicitudin. Sed ac neque cursus, 
+Ornare Augue grilentesque, Elementum Turpis.
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq8" aria-expanded="false" aria-controls="faq8" data-i18n="can_i_sell_my_property_through_rofaria" data-sb-field-path="faqs[7].question">
+                                            Vai es varu pārdot savu īpašumu caur Rofaria?
+                                        </button>
+                                    </h2>
+                                    <div id="faq8" class="accordion-collapse collapse" data-bs-parent="#faqAccordion2">
+                                        <div class="accordion-body" data-i18n="lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_donec_vel_erat_nibh_sed_rutrum_turpis_quis_lacinia_sollicitudin_sed_ac_neque_cursus_ornare_augue_pellentesque_elementum_turpis" data-sb-field-path="faqs[7].answer">
+                                            Lorem ipsum dolor sēž amet, consectetur adipiscing elit. Donec vel erat 
+nibh. Sed Rutrum Turpis quis lacinia solicitudin. Sed ac neque cursus, 
+Ornare Augue grilentesque, Elementum Turpis.
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq9" aria-expanded="false" aria-controls="faq9" data-i18n="are_properties_available_in_different_price_ranges" data-sb-field-path="faqs[8].question">
+                                            Vai īpašumi ir pieejami dažādos cenu diapazonos?
+                                        </button>
+                                    </h2>
+                                    <div id="faq9" class="accordion-collapse collapse" data-bs-parent="#faqAccordion2">
+                                        <div class="accordion-body" data-i18n="lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_donec_vel_erat_nibh_sed_rutrum_turpis_quis_lacinia_sollicitudin_sed_ac_neque_cursus_ornare_augue_pellentesque_elementum_turpis" data-sb-field-path="faqs[8].answer">
+                                            Lorem ipsum dolor sēž amet, consectetur adipiscing elit. Donec vel erat 
+nibh. Sed Rutrum Turpis quis lacinia solicitudin. Sed ac neque cursus, 
+Ornare Augue grilentesque, Elementum Turpis.
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#faq10" aria-expanded="false" aria-controls="faq10" data-i18n="how_can_i_start_searching_for_properties_on_this_website" data-sb-field-path="faqs[9].question">
+                                            Kā es varu sākt meklēt īpašumus šajā vietnē?
+                                        </button>
+                                    </h2>
+                                    <div id="faq10" class="accordion-collapse collapse show" data-bs-parent="#faqAccordion2">
+                                        <div class="accordion-body" data-i18n="simply_use_the_search_feature_on_the_homepage_to_filter_properties_by_location_price_number_of_rooms_and_more_for_personalized_recommendations_or_further_assistance_feel_free_to_contact_our_team" data-sb-field-path="faqs[9].answer">
+                                            Vienkārši izmantojiet meklēšanas funkciju mājas lapā, lai filtrētu rekvizītus pēc 
+Atrašanās vieta, cena, istabu skaits un daudz kas cits. Personalizētiem ieteikumiem 
+Vai arī turpmāka palīdzība, sazinieties ar mūsu komandu.
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    </main>
+
+    <footer>
+        <div class="section position-relative bg-black-1" style="height: 90vh;">
+            <div class="row row-cols-xl-2 row-cols-1 h-100">
+                <div class="col col-xl-8 mb-3">
+                    <div class="d-flex flex-column gap-3 justify-content-between h-100">
+                        <div class="d-flex flex-column accent-primary">
+                            <p class="gray" data-i18n="get_contact">Sazināties</p>
+                            <h1 class="fw-normal" data-i18n="hellodomainsitecom">hello@omainsite.com</h1>
+                        </div>
+                        <img src="../image/logo-footer.png?v=2025" alt="Vandore Heritage" class="img-fluid" width="938">
+                    </div>
+                </div>
+                <div class="col col-xl-4 mb-3">
+                    <div class="d-flex flex-column gap-5 justify-content-between accent-primary h-100">
+                        <div class="d-flex flex-row gap-5">
+                            <ul class="list-unstyled d-flex flex-column gap-3 accent-color">
+                                <li>
+                                    <a href="index.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="home">
+                                        Mājas
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="about.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="about">
+                                        Pret
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="properties.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="properties">
+                                        Īpašības
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="rentals.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="rentals">
+                                        Īre
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="service.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="service">
+                                        Sakārtošana
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="contact.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="contact_us">
+                                        Sazinieties ar mums
+                                    </a>
+                                </li>
+                            </ul>
+                            <div class="d-flex flex-column gap-3">
+                                <a href="https://www.facebook.com" class="link" data-i18n="kllg_st_no99_pku_city_id_28289">
+                                    Kllg St, Nr.99, PKU City, ID 28289
+                                </a>
+                                <a href="https://www.instagram.com" class="link" data-i18n="1_212_5551212">
+                                    +1 (212) 555-1212
+                                </a>
+                            </div>
+                        </div>
+                        <div class="d-flex flex-row gap-3">
+                            <div class="border-end pe-3 border-gray">
+                                <a href="" class="link d-flex flex-row gap-3 align-items-center" data-i18n="terms_conditions">
+                                    Noteikumi un nosacījumi
+                                </a>
+                            </div>
+                            <div>
+                                <a href="" class="link d-flex flex-row gap-3 align-items-center" data-i18n="privacy_notice">
+                                    Paziņojums par privātumu
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+
+    <!-- Back to top button -->
+    <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="rtmicon rtmicon-arrow-up"></i></a>
+
+    <!-- Scripts -->
+    <script src="../js/vendor/jquery.min.js"></script>
+    <script src="../js/vendor/bootstrap.bundle.min.js"></script>
+    <script src="../js/vendor/swiper-bundle.min.js"></script>
+    <script src="../js/script.js"></script>
+    <script src="../js/swiper-script.js"></script>
+    <script src="../js/submit-form.js"></script>
+    <script src="../js/vendor/isotope.pkgd.min.js"></script>
+    <script src="../js/video_embedded.js"></script>
+    <script src="../js/vendor/fslightbox.js"></script>
+    <script src="../js/custom.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.0/oyethemes_onscroll_animation.js"></script>
+
+
+
+</body></html>

--- a/_site/price_plan.html
+++ b/_site/price_plan.html
@@ -1,0 +1,520 @@
+<!DOCTYPE html><html lang="lv" data-sb-object-id="content/pages/price_plan.json"><head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;600&family=Noto+Serif:wght@700&display=swap&subset=latin-ext" rel="stylesheet">
+    <link rel="stylesheet" href="../css/style.css">
+    <link rel="stylesheet" href="../css/changes.css">
+    <link rel="stylesheet" href="../css/custom.css">
+    <link rel="stylesheet" href="../css/fonts.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.2/animation_utility.css">
+    <link rel="icon" type="image/x-icon" href="../image/red_LOGO_Vandore.png?v=2025">
+    <title data-i18n="vandore_heritage_pricing_plan" data-sb-field-path="title">Vandore Heritage - cenu noteikšanas plāns</title>
+</head>
+
+<body>
+    <!-- Header -->
+    <header class="bg-accent-primary px-5">
+        <nav class="navbar">
+            <div class="container-fluid ps-3 gap-3">
+                <div class="me-auto"></div>
+                <div class="logo-container position-absolute start-50 translate-middle-x" style="margin-top: 2cm;">
+                    <a class="navbar-brand" href="index.html"><img src="../image/red_LOGO_Vandore.png?v=2025" alt="Vandore Heritage" class="img-fluid"></a>
+                </div>
+                <div class="w-max-content" style="margin-top: 0.5cm;">
+                    <button class="btn btn-toggler-accent" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDark" aria-controls="offcanvasDark"><i class="fa-solid fa-bars"></i>
+                        Menu</button>
+
+                    <div class="offcanvas offcanvas-end offcanvas-fullwidth text-bg-dark" tabindex="-1" id="offcanvasDark" aria-labelledby="offcanvasRightLabel">
+                        <div class="offcanvas-header bg-transparent">
+                            <h5 id="offcanvasRightLabel">Menu</h5>
+                            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+                        </div>
+                        <div class="offcanvas-body">
+                            <div class="r-container">
+                                <div class="row row-cols-xl-2 row-cols-1">
+                                    <div class="col col-xl-10 mb-3">
+                                        <div class="d-flex flex-column">
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="01_homepage">01. Mājas lapa</span>
+                                                <img src="../image/img6.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="index.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="02_properties">02. Īpašumi</span>
+                                                <img src="../image/img5.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="properties.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="03_short_form_rentals">03. Īsas formas īre</span>
+                                                <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="rentals.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="04_about_us">04. Par mums</span>
+                                                <img src="../image/img33.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="about.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="05_services">05. Pakalpojumi</span>
+                                                <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="service.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="06_contact">06. Sazinieties</span>
+                                                <img src="../image/img29.png" class="img-fluid rounded-3 " style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="contact.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="07_news">07. Jaunumi</span>
+                                                <img src="../image/img26.png" class="img-fluid rounded-3 " style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="blog.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col col-xl-2 mb-3">
+                                        <div class="d-flex flex-column gap-5 accent-primary text-end">
+                                           <div class="d-flex flex-column gap-4">
+                                                <h6 data-i18n="riga_latvia">Rīga, Latvija</h6>
+                                                <div class="d-flex flex-column gap-3">
+                                                    <span data-i18n="skanstes_iela_29a91_rga_latvia">
+                                                        Skanstes Iela 29A - 91, Rīga, Latvija
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </nav>
+    </header>
+    <!-- End Header -->
+
+    <!-- Main -->
+    <main>
+        <!-- Banner -->
+        <div class="section position-relative bg-attach-cover">
+            <div class="r-container position-relative h-100">
+                <div class="position-absolute top-0 start-0 end-0 bottom-0 h-100 w-100" style="margin-top: 10rem;">
+                    <div class="row row-cols-2">
+                        <div class="col-3 col-xl-2"></div>
+                        <div class="col-9 col-xl-10">
+                            <img src="../image/dummy-img-1920x900.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Vandore Heritage">
+                        </div>
+                    </div>
+                </div>
+                <div class="d-flex flex-column gap-5 justify-content-between scrollanimation animated fadeInLeft adr-7 h-100 padding-custom">
+                    <div class="d-flex flex-column gap-2 h-100">
+                        <div><h1 class="display" style="max-width: 700px;" data-i18n="pricing_plan" data-sb-field-path="heroHeading">Cenu plāns</h1>
+                        <div class="row row-xl-cols-2 row-cols-1">
+                            <div class="col col-xl-2">
+                                <div class="d-flex flex-column gap-2 align-items-xl-center align-items-start">
+                                    <p data-i18n="explore_flexible_pricing_options_designed_to_meet_your_real_estate_needs_and_budget" data-sb-field-path="heroSubheading">Izpētiet elastīgas cenu noteikšanas iespējas, kas paredzētas, lai apmierinātu jūsu vajadzības ar nekustamo īpašumu un 
+budžets.
+                                    </p></div>
+                                    <div class="devider"></div>
+                                </div>
+                            </div>
+                            <div class="col col-xl-10"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Section Pricing -->
+        <div class="section">
+            <div class="r-container d-flex flex-column gap-5">
+                <div class="d-flex flex-column gap-2 align-items-center justify-content-center mx-auto text-center scrollanimation animated fadeInDown adr-7" data-sb-field-path="sections">
+                    <h3 data-i18n="flexible_pricing_plans_for_every_need" data-sb-field-path="sections[0].heading">Elastīgi cenu plāni katrai vajadzībai</h3>
+                    <p style="max-width: 800px;" data-i18n="choose_from_a_variety_of_flexible_pricing_plans_designed_to_fit_your_budget_while_meeting_your_real_estate_needs_with_great_value_and_convenience" data-sb-field-path="sections[0].text">
+                        Izvēlieties no dažādiem elastīgiem cenu plāniem, kas izstrādāti, lai tie atbilstu jūsu budžetam 
+Nekustamā īpašuma vajadzības ar lielu vērtību un ērtībām.
+                    </p>
+                </div>
+                <div class="row row-cols-xl-3 row-cols-1">
+                    <div class="col mb-3 scrollanimation animated fadeInLeft adr-7">
+                        <div class="card card-pricing">
+                            <div class="d-flex flex-column gap-5 position-relative" style="z-index: 3;">
+                                <div class="d-flex flex-column gap-2">
+                                    <h4 class="black-1" data-i18n="basic_plan">Pamata plāns</h4>
+                                    <div class="d-flex flex-row heading mb-3 align-items-end">
+                                        <h3 class="m-0 fw-semibold" data-i18n="199">199 USD</h3>
+                                        <h4 class="gray" data-i18n="month">/mēnesis</h4>
+                                    </div>
+                                    <p class="m-0" data-i18n="for_individuals_looking_for_affordable_real_estate_assistance">
+                                        Personām, kas meklē pieejamu nekustamā īpašuma palīdzību.
+                                    </p>
+                                </div>
+                                <a href="" class="btn btn-accent d-flex flex-row gap-3 justify-content-center">
+                                    <span data-i18n="choose_plan">Izvēlieties plānu</span>
+                                    <i class="rtmicon rtmicon-arrow-up-right fw-bold"></i>
+                                </a>
+                                <div class="d-flex flex-column gap-4">
+                                    <div class="d-flex flex-row gap-3 align-items-center text-color-2">
+                                        <div class="social-item">
+                                            <i class="rtmicon rtmicon-check fw-bold"></i>
+                                        </div>
+                                        <h6 class="m-0" data-i18n="property_listings_access">Īpašumu saraksta piekļuve</h6>
+                                    </div>
+                                    <div class="d-flex flex-row gap-3 align-items-center text-color-2">
+                                        <div class="social-item">
+                                            <i class="rtmicon rtmicon-check fw-bold"></i>
+                                        </div>
+                                        <h6 class="m-0" data-i18n="basic_consultation_1_session">Pamata konsultācija (1 sesija)</h6>
+                                    </div>
+                                    <div class="d-flex flex-row gap-3 align-items-center text-color-2">
+                                        <div class="social-item">
+                                            <i class="rtmicon rtmicon-check fw-bold"></i>
+                                        </div>
+                                        <h6 class="m-0" data-i18n="email_support">E -pasta atbalsts</h6>
+                                    </div>
+                                    <div class="d-flex flex-row gap-3 align-items-center text-color-2">
+                                        <div class="social-item">
+                                            <i class="rtmicon rtmicon-check fw-bold"></i>
+                                        </div>
+                                        <h6 class="m-0" data-i18n="monthly_market_insights">Ikmēneša tirgus ieskats</h6>
+                                    </div>
+                                    <div class="d-flex flex-row gap-3 align-items-center text-color-2">
+                                        <div class="social-item">
+                                            <i class="rtmicon rtmicon-check fw-bold"></i>
+                                        </div>
+                                        <h6 class="m-0" data-i18n="weekly_webinars">Iknedēļas vebināri</h6>
+                                    </div>
+                                    <div class="d-flex flex-row gap-3 align-items-center text-color-2">
+                                        <div class="social-item">
+                                            <i class="rtmicon rtmicon-check fw-bold"></i>
+                                        </div>
+                                        <h6 class="grey-hover m-0" data-i18n="premium_support">Premium atbalsts</h6>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col mb-3 scrollanimation animated fadeIn adr-7">
+                        <div class="card card-pricing">
+                            <div class="d-flex flex-column gap-5 position-relative" style="z-index: 3;">
+                                <div class="d-flex flex-column gap-2">
+                                    <h4 class="black-1" data-i18n="premium_plan">Premium plāns</h4>
+                                    <div class="d-flex flex-row heading mb-3 align-items-end">
+                                        <h3 class="m-0 fw-semibold" data-i18n="499">499 USD</h3>
+                                        <h4 class="gray" data-i18n="month">/mēnesis</h4>
+                                    </div>
+                                    <p class="m-0" data-i18n="ideal_for_serious_buyers_sellers_and_investors_needing_expert_guidance">
+                                        Ideāli piemērots nopietniem pircējiem, pārdevējiem un investoriem, kuriem nepieciešami ekspertu norādījumi.
+                                    </p>
+                                </div>
+                                <a href="" class="btn btn-accent d-flex flex-row gap-3 justify-content-center">
+                                    <span data-i18n="choose_plan">Izvēlieties plānu</span>
+                                    <i class="rtmicon rtmicon-arrow-up-right fw-bold"></i>
+                                </a>
+                                <div class="d-flex flex-column gap-4">
+                                    <div class="d-flex flex-row gap-3 align-items-center text-color-2">
+                                        <div class="social-item">
+                                            <i class="rtmicon rtmicon-check fw-bold"></i>
+                                        </div>
+                                        <h6 class="m-0" data-i18n="all_basic_plan_features">Visas pamatplāna funkcijas</h6>
+                                    </div>
+                                    <div class="d-flex flex-row gap-3 align-items-center text-color-2">
+                                        <div class="social-item">
+                                            <i class="rtmicon rtmicon-check fw-bold"></i>
+                                        </div>
+                                        <h6 class="m-0" data-i18n="property_recommendations">Īpašuma ieteikumi</h6>
+                                    </div>
+                                    <div class="d-flex flex-row gap-3 align-items-center text-color-2">
+                                        <div class="social-item">
+                                            <i class="rtmicon rtmicon-check fw-bold"></i>
+                                        </div>
+                                        <h6 class="m-0" data-i18n="priority_consultation_3_sessions">Prioritārā konsultācija (3 sesijas)</h6>
+                                    </div>
+                                    <div class="d-flex flex-row gap-3 align-items-center text-color-2">
+                                        <div class="social-item">
+                                            <i class="rtmicon rtmicon-check fw-bold"></i>
+                                        </div>
+                                        <h6 class="m-0" data-i18n="legal_document_assistance">Likumīga dokumenta palīdzība</h6>
+                                    </div>
+                                    <div class="d-flex flex-row gap-3 align-items-center text-color-2">
+                                        <div class="social-item">
+                                            <i class="rtmicon rtmicon-check fw-bold"></i>
+                                        </div>
+                                        <h6 class="m-0" data-i18n="customized_investment_strategies">Pielāgotas investīciju stratēģijas</h6>
+                                    </div>
+                                    <div class="d-flex flex-row gap-3 align-items-center text-color-2">
+                                        <div class="social-item">
+                                            <i class="rtmicon rtmicon-check fw-bold"></i>
+                                        </div>
+                                        <h6 class="m-0" data-i18n="market_trends_analysis">Tirgus tendenču analīze</h6>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col mb-3 scrollanimation animated fadeInRight adr-7">
+                        <div class="card card-pricing">
+                            <div class="d-flex flex-column gap-5 position-relative" style="z-index: 3;">
+                                <div class="d-flex flex-column gap-2">
+                                    <h4 class="black-1" data-i18n="vip_plan">VIP plāns</h4>
+                                    <div class="d-flex flex-row heading mb-3 align-items-end">
+                                        <h3 class="m-0 fw-semibold" data-i18n="999">999 USD</h3>
+                                        <h4 class="gray" data-i18n="month">/mēnesis</h4>
+                                    </div>
+                                    <p class="m-0" data-i18n="exclusive_service_for_highend_clients_investors_and_others">
+                                        Ekskluzīvs pakalpojums augstākās klases klientiem, investoriem un citiem.
+                                    </p>
+                                </div>
+                                <a href="" class="btn btn-accent d-flex flex-row gap-3 justify-content-center">
+                                    <span data-i18n="choose_plan">Izvēlieties plānu</span>
+                                    <i class="rtmicon rtmicon-arrow-up-right fw-bold"></i>
+                                </a>
+                                <div class="d-flex flex-column gap-4">
+                                    <div class="d-flex flex-row gap-3 align-items-center text-color-2">
+                                        <div class="social-item">
+                                            <i class="rtmicon rtmicon-check fw-bold"></i>
+                                        </div>
+                                        <h6 class="m-0" data-i18n="all_premium_plan_features">Visas premium plāna funkcijas</h6>
+                                    </div>
+                                    <div class="d-flex flex-row gap-3 align-items-center text-color-2">
+                                        <div class="social-item">
+                                            <i class="rtmicon rtmicon-check fw-bold"></i>
+                                        </div>
+                                        <h6 class="m-0" data-i18n="dedicated_real_estate_advisor">Īpašs nekustamā īpašuma konsultants</h6>
+                                    </div>
+                                    <div class="d-flex flex-row gap-3 align-items-center text-color-2">
+                                        <div class="social-item">
+                                            <i class="rtmicon rtmicon-check fw-bold"></i>
+                                        </div>
+                                        <h6 class="m-0" data-i18n="unlimited_consultations">Neierobežotas konsultācijas</h6>
+                                    </div>
+                                    <div class="d-flex flex-row gap-3 align-items-center text-color-2">
+                                        <div class="social-item">
+                                            <i class="rtmicon rtmicon-check fw-bold"></i>
+                                        </div>
+                                        <h6 class="m-0" data-i18n="investment_strategy_planning">Investīciju stratēģijas plānošana</h6>
+                                    </div>
+                                    <div class="d-flex flex-row gap-3 align-items-center text-color-2">
+                                        <div class="social-item">
+                                            <i class="rtmicon rtmicon-check fw-bold"></i>
+                                        </div>
+                                        <h6 class="m-0" data-i18n="secure_document_storage">Droša dokumentu glabāšana</h6>
+                                    </div>
+                                    <div class="d-flex flex-row gap-3 align-items-center text-color-2">
+                                        <div class="social-item">
+                                            <i class="rtmicon rtmicon-check fw-bold"></i>
+                                        </div>
+                                        <h6 class="grey-hover m-0" data-i18n="property_visits_virtual_tours">Īpašuma apmeklējumi un virtuālās ekskursijas</h6>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Section FAQs -->
+        <div class="section bg-attach-cover" style="background-image: url(../image/bg_faq.png);">
+            <div class="r-container">
+                <div class="row row-cols-xl-2 row-cols-1">
+                    <div class="col mb-3 scrollanimation animated fadeInLeft adr-7">
+                        <div class="d-flex flex-column gap-5">
+                            <h3 style="max-width: 400px;" data-i18n="client_support_questions">Klienta atbalsta jautājumi</h3>
+                            <div class="w-max-content" style="justify-self: end;">
+                                <a href="faq.html" class="btn btn-accent d-flex flex-row gap-2 justify-content-center">
+                                    <span data-i18n="still_have_question">Joprojām ir jautājums?</span>
+                                    <i class="rtmicon rtmicon-arrow-up-right fw-bold"></i>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col mb-3">
+                        <div class="d-flex flex-column gap-4 w-100">
+                            <div class="accordion mt-3 d-flex flex-column gap-4" id="faqAccordion1">
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq1" aria-expanded="false" aria-controls="faq1" data-i18n="do_you_only_work_with_luxury_properties">
+                                            Vai jūs strādājat tikai ar luksusa īpašumiem?
+                                        </button>
+                                    </h2>
+                                    <div id="faq1" class="accordion-collapse collapse" data-bs-parent="#faqAccordion1">
+                                        <div class="accordion-body" data-i18n="partly_focus_is_on_exclusive_properties_but_also_on_projects_with_potential">
+                                            Daļēji. Koncentrēšanās ir uz ekskluzīviem īpašumiem, bet arī uz projektiem ar potenciālu.
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#faq2" aria-expanded="true" aria-controls="faq2" data-i18n="what_makes_you_different_from_other_agencies">
+                                            Kas padara jūs atšķirīgu no citām aģentūrām?
+                                        </button>
+                                    </h2>
+                                    <div id="faq2" class="accordion-collapse collapse show" data-bs-parent="#faqAccordion1">
+                                        <div class="accordion-body" data-i18n="fullservice_adaptable_detailed_combining_sales_rentals_renovation_design_and_legal_support">
+                                            Pilna servisa, pielāgojama, detalizēta, pārdošanas, īres, atjaunošanas, dizaina un juridiskā atbalsta apvienošana.
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq3" aria-expanded="false" aria-controls="faq3" data-i18n="how_fast_can_you_put_a_property_on_the_market">
+                                            Cik ātri jūs varat ievietot nekustamo īpašumu tirgū?
+                                        </button>
+                                    </h2>
+                                    <div id="faq3" class="accordion-collapse collapse" data-bs-parent="#faqAccordion1">
+                                        <div class="accordion-body" data-i18n="publication_is_fast_but_most_time_goes_into_market_analysis_and_precise_pricing">
+                                            Publikācija ir ātra, bet lielākā daļa laika tiek veikta tirgus analīzē un precīzas cenās.
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq4" aria-expanded="false" aria-controls="faq4" data-i18n="how_do_you_prepare_a_property_for_salerent">
+                                            Kā jūs sagatavojat īpašumu pārdošanai/īrei?
+                                        </button>
+                                    </h2>
+                                    <div id="faq4" class="accordion-collapse collapse" data-bs-parent="#faqAccordion1">
+                                        <div class="accordion-body" data-i18n="evaluation_strategy_improvements_cleaning_styling_professional_photosvideo">
+                                            Novērtēšana → Stratēģija → Uzlabojumi → Tīrīšana → Stils → Profesionāli fotoattēli/video.
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq5" aria-expanded="false" aria-controls="faq5" data-i18n="how_do_you_set_the_best_price">
+                                            Kā jūs iestatāt labāko cenu?
+                                        </button>
+                                    </h2>
+                                    <div id="faq5" class="accordion-collapse collapse" data-bs-parent="#faqAccordion1">
+                                        <div class="accordion-body" data-i18n="market_research_property_potential_client_goals_plus_independent_valuers_if_needed">
+                                            Tirgus izpēte, īpašuma potenciāls, klienta mērķi, kā arī neatkarīgi vērtētāji, ja nepieciešams.
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    </main>
+
+    <footer>
+        <div class="section position-relative bg-black-1" style="height: 90vh;">
+            <div class="row row-cols-xl-2 row-cols-1 h-100">
+                <div class="col col-xl-8 mb-3">
+                    <div class="d-flex flex-column gap-3 justify-content-between h-100">
+                        <div class="d-flex flex-column accent-primary">
+                            <p class="gray" data-i18n="get_contact">Sazināties</p>
+                            <h1 class="fw-normal" data-i18n="infovandoreheritagelv">info@vandoreheritage.lv</h1>
+                        </div>
+                        <img src="../image/logo-footer.png?v=2025" alt="Vandore Heritage" class="img-fluid" width="938">
+                    </div>
+                </div>
+                <div class="col col-xl-4 mb-3">
+                    <div class="d-flex flex-column gap-5 justify-content-between accent-primary h-100">
+                        <div class="d-flex flex-row gap-5">
+                            <ul class="list-unstyled d-flex flex-column gap-3 accent-color">
+                                <li>
+                                    <a href="index.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="home">
+                                        Mājas
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="about.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="about">
+                                        Pret
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="properties.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="properties">
+                                        Īpašības
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="rentals.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="rentals">
+                                        Īre
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="service.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="service">
+                                        Sakārtošana
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="contact.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="contact_us">
+                                        Sazinieties ar mums
+                                    </a>
+                                </li>
+                            </ul>
+                            <div class="d-flex flex-column gap-3">
+                                <a href="https://www.google.com/maps/place/Skanstes+iela+29A,+Vidzemes+priekšpilsēta,+Rīga,+LV-1013,+Latvia" class="link" target="_blank" data-i18n="skanstes_iela_29a91_rga_latvia">
+                                    Skanstes Iela 29A - 91, Rīga, Latvija
+                                </a>
+                                <a href="tel:+37129713030" class="link" data-i18n="371_29_71_3030">
+                                    +371 29 71 3030
+                                </a>
+                            </div>
+                        </div>
+                        <div class="d-flex flex-row gap-3">
+                            <div class="border-end pe-3 border-gray">
+                                <a href="" class="link d-flex flex-row gap-3 align-items-center" data-i18n="terms_conditions">
+                                    Noteikumi un nosacījumi
+                                </a>
+                            </div>
+                            <div>
+                                <a href="" class="link d-flex flex-row gap-3 align-items-center" data-i18n="privacy_notice">
+                                    Paziņojums par privātumu
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+
+    <!-- Back to top button -->
+    <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="rtmicon rtmicon-arrow-up"></i></a>
+
+    <!-- Scripts -->
+    <script src="../js/vendor/jquery.min.js"></script>
+    <script src="../js/vendor/bootstrap.bundle.min.js"></script>
+    <script src="../js/vendor/swiper-bundle.min.js"></script>
+    <script src="../js/script.js"></script>
+    <script src="../js/swiper-script.js"></script>
+    <script src="../js/submit-form.js"></script>
+    <script src="../js/vendor/isotope.pkgd.min.js"></script>
+    <script src="../js/video_embedded.js"></script>
+    <script src="../js/vendor/fslightbox.js"></script>
+    <script src="../js/custom.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.0/oyethemes_onscroll_animation.js"></script>
+
+
+
+</body></html>

--- a/_site/properties.html
+++ b/_site/properties.html
@@ -1,0 +1,638 @@
+<!DOCTYPE html><html lang="lv" data-sb-object-id="content/pages/properties.json"><head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;600&family=Noto+Serif:wght@700&display=swap&subset=latin-ext" rel="stylesheet">
+    <link rel="stylesheet" href="../css/style.css">
+    <link rel="stylesheet" href="../css/custom.css">
+    <link rel="stylesheet" href="../css/fonts.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.2/animation_utility.css">
+    <link rel="icon" type="image/x-icon" href="../image/red_LOGO_Vandore.png?v=2025">
+    <title data-i18n="vandore_heritage_properties" data-sb-field-path="title">Vandore Heritage - īpašības</title>
+</head>
+
+<body class="properties-page">
+    <!-- Header -->
+    <header class="bg-accent-primary px-5">
+        <nav class="navbar">
+            <div class="container-fluid ps-3 gap-3">
+                <div class="me-auto"></div>
+                <div class="logo-container position-absolute start-50 translate-middle-x" style="margin-top: 2cm;">
+                    <a class="navbar-brand" href="index.html"><img src="../image/red_LOGO_Vandore.png?v=2025" alt="Vandore Heritage" class="img-fluid"></a>
+                </div>
+                <div class="w-max-content" style="margin-top: 0.5cm;">
+                    <button class="btn btn-toggler-accent" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDark" aria-controls="offcanvasDark"><i class="fa-solid fa-bars"></i>
+                        Menu</button>
+
+                    <div class="offcanvas offcanvas-end offcanvas-fullwidth text-bg-dark" tabindex="-1" id="offcanvasDark" aria-labelledby="offcanvasRightLabel">
+                        <div class="offcanvas-header bg-transparent">
+                            <h5 id="offcanvasRightLabel">Menu</h5>
+                            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+                        </div>
+                        <div class="offcanvas-body">
+                            <div class="r-container">
+                                <div class="row row-cols-xl-2 row-cols-1">
+                                    <div class="col col-xl-10 mb-3">
+                                        <div class="d-flex flex-column">
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="01_homepage">01. Mājas lapa</span>
+                                                <img src="../image/img6.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="index.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="02_properties">02. Īpašumi</span>
+                                                <img src="../image/img5.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="properties.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="03_short_form_rentals">03. Īsas formas īre</span>
+                                                <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="rentals.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="04_about_us">04. Par mums</span>
+                                                <img src="../image/img33.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="about.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="05_services">05. Pakalpojumi</span>
+                                                <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="service.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="06_contact">06. Sazinieties</span>
+                                                <img src="../image/img29.png" class="img-fluid rounded-3 " style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="contact.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="07_news">07. Jaunumi</span>
+                                                <img src="../image/img26.png" class="img-fluid rounded-3 " style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="blog.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col col-xl-2 mb-3">
+                                        <div class="d-flex flex-column gap-5 accent-primary text-end">
+                                           <div class="d-flex flex-column gap-4">
+                                                <h6 data-i18n="riga_latvia">Rīga, Latvija</h6>
+                                                <div class="d-flex flex-column gap-3">
+                                                    <span data-i18n="skanstes_iela_29a91_rga_latvia">
+                                                        Skanstes Iela 29A - 91, Rīga, Latvija
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </nav>
+    </header>
+    <!-- End Header -->
+
+    <!-- Main -->
+    <main>
+        <!-- Banner -->
+        <div class="section position-relative bg-attach-cover">
+            <div class="r-container position-relative h-100">
+                <div class="position-absolute top-0 start-0 end-0 bottom-0 h-100 w-100" style="margin-top: 10rem;">
+                    <div class="row row-cols-2">
+                        <div class="col-3 col-xl-2"></div>
+                        <div class="col-9 col-xl-10">
+                            <img src="../image/dummy-img-1920x900.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Vandore Heritage">
+                        </div>
+                    </div>
+                </div>
+                <div class="d-flex flex-column gap-5 justify-content-between scrollanimation animated fadeInLeft adr-7 h-100 padding-custom">
+                    <div class="d-flex flex-column gap-2 h-100">
+                        <div><h1 class="display" style="max-width: 700px;" data-i18n="properties" data-sb-field-path="heroHeading">Īpašības</h1>
+                        <div class="row row-xl-cols-2 row-cols-1">
+                            <div class="col col-xl-2">
+                                <div class="d-flex flex-column gap-2 align-items-xl-center align-items-start">
+                                    <p data-i18n="discover_carefully_selected_homes_and_spaces_across_riga_chosen_for_their_quality_character_and_individuality" data-sb-field-path="heroSubheading">Atklājiet rūpīgi atlasītas mājas un telpas visā Rīgā, izvēloties to kvalitāti, raksturu un individualitāti.</p></div>
+                                    <div class="devider"></div>
+                                </div>
+                            </div>
+                            <div class="col col-xl-10"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Section Featured Properties -->
+        <div class="section">
+            <div class="r-container d-flex flex-column gap-5">
+                <div class="row row-cols-xl-2 row-cols-1 align-items-end">
+                    <div class="col mb-3 scrollanimation animated fadeInLeft adr-7">
+                        <h3 style="max-width: 400px;" data-i18n="explore_featured_homes">Izpētiet piedāvātās mājas</h3>
+                    </div>
+                    <div class="col mb-3 scrollanimation animated fadeInDown adr-7">
+                        <div class="d-flex flex-column gap-2 align-items-end">
+                            <div class="w-max-content" style="justify-self: end;">
+                                <a href="property_detail.html" class="btn btn-accent d-flex flex-row gap-2 justify-content-center">
+                                    <span data-i18n="contact_our_agents">Sazinieties ar mūsu aģentiem</span>
+                                    <i class="rtmicon rtmicon-arrow-up-right fw-bold"></i>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-12">
+                        <div class="filter-bar card p-4">
+                            <div class="row g-3 align-items-end">
+                                <div class="col-12 col-md-4">
+                                    <label for="location-search" data-i18n="location">Atrašanās vieta</label>
+                                    <input type="text" id="location-search" class="form-control" placeholder="Pilsēta / rajons / apkaime">
+                                </div>
+                                <div class="col-6 col-md-2">
+                                    <label for="min-price" data-i18n="min_price">Min. cena (€)</label>
+                                    <input type="number" id="min-price" class="form-control" placeholder="0" min="0">
+                                </div>
+                                <div class="col-6 col-md-2">
+                                    <label for="max-price" data-i18n="max_price">Maks. cena (€)</label>
+                                    <input type="number" id="max-price" class="form-control" placeholder="100000" min="0">
+                                </div>
+                                <div class="col-6 col-md-2">
+                                    <label for="bedrooms-prop" data-i18n="bedrooms">Guļamistabas</label>
+                                    <select id="bedrooms-prop" class="form-select">
+                                        <option value="" data-i18n="all">Visas</option>
+                                        <option>1</option>
+                                        <option>2</option>
+                                        <option>3+</option>
+                                    </select>
+                                </div>
+                                <div class="col-6 col-md-2">
+                                    <div class="d-grid gap-2">
+                                        <button class="btn btn-primary" id="apply-filters" data-i18n="apply">Piemērot</button>
+                                        <button class="btn btn-secondary" id="clear-filters" data-i18n="clear">Notīrīt</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="active-filters my-3">
+                            <span id="filter-chips"></span>
+                            <span id="property-count" class="ms-2"></span>
+                        </div>
+                        <div class="filter-drawer d-none">
+                            <button class="btn btn-primary w-100 mb-3" type="button" data-bs-toggle="offcanvas" data-bs-target="#filter-drawer" aria-controls="filter-drawer" data-i18n="filters">
+                                Filtri
+                            </button>
+                        </div>
+                        <div class="offcanvas-lg offcanvas-start" tabindex="-1" id="filter-drawer" aria-labelledby="filter-drawer-label" style="display:none">
+                            <div class="offcanvas-header">
+                                <h5 class="offcanvas-title" id="filter-drawer-label" data-i18n="filters">Filtri</h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="offcanvas" data-bs-target="#filter-drawer" aria-label="Close"></button>
+                            </div>
+                            <div class="offcanvas-body">
+                                <div class="filter-bar">
+                                    <div class="row g-3">
+                                        <div class="col-12">
+                                            <div class="form-group">
+                                                <label for="location-search" data-i18n="location">Atrašanās vieta</label>
+                                                <input type="text" id="location-search-mobile" class="form-control" placeholder="Pilsēta/Rajons/Apkaime">
+                                            </div>
+                                        </div>
+                                        <div class="col-12">
+                                            <label data-i18n="price_range">Cenu diapazons</label>
+                                            <div class="input-group">
+                                                <input type="number" id="min-price-mobile" class="form-control" placeholder="Min €" min="0">
+                                                <input type="number" id="max-price-mobile" class="form-control" placeholder="Max €" min="0">
+                                            </div>
+                                        </div>
+                                        <div class="col-12">
+                                            <label data-i18n="bedrooms">Guļamistabas</label>
+                                            <div class="btn-group" role="group">
+                                                <button type="button" class="btn btn-outline-primary active" data-i18n="all">Viss</button>
+                                                <button type="button" class="btn btn-outline-primary" data-i18n="1">Viens</button>
+                                                <button type="button" class="btn btn-outline-primary" data-i18n="2">Rādītājs</button>
+                                                <button type="button" class="btn btn-outline-primary" data-i18n="3">3</button>
+                                                <button type="button" class="btn btn-outline-primary" data-i18n="4">4</button>
+                                                <button type="button" class="btn btn-outline-primary" data-i18n="5+">5+</button>
+                                            </div>
+                                        </div>
+                                        <div class="col-12">
+                                            <div class="d-grid gap-2">
+                                                <button class="btn btn-primary" id="apply-filters-mobile" data-i18n="apply">Piemērot</button>
+                                                <button class="btn btn-secondary" id="clear-filters-mobile" data-i18n="clear">Noskaidrot</button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="filter-bar d-none d-lg-block bg-white p-3 rounded-3" style="display:none">
+                            <div class="row g-3">
+                                <div class="col-lg-3 col-md-6">
+                                    <div class="form-group">
+                                        <label for="location-search" data-i18n="location">Atrašanās vieta</label>
+                                        <input type="text" id="location-search" class="form-control" placeholder="Pilsēta/Rajons/Apkaime">
+                                    </div>
+                                </div>
+                                <div class="col-lg-3 col-md-6">
+                                    <label data-i18n="price_range">Cenu diapazons</label>
+                                    <div class="input-group">
+                                        <input type="number" id="min-price" class="form-control" placeholder="Min €" min="0">
+                                        <input type="number" id="max-price" class="form-control" placeholder="Max €" min="0">
+                                    </div>
+                                </div>
+                                <div class="col-lg-4 col-md-12">
+                                    <label data-i18n="bedrooms">Guļamistabas</label>
+                                    <div class="btn-group" role="group">
+                                        <button type="button" class="btn btn-outline-primary active" data-i18n="all">Viss</button>
+                                        <button type="button" class="btn btn-outline-primary" data-i18n="1">Viens</button>
+                                        <button type="button" class="btn btn-outline-primary" data-i18n="2">Rādītājs</button>
+                                        <button type="button" class="btn btn-outline-primary" data-i18n="3">3</button>
+                                        <button type="button" class="btn btn-outline-primary" data-i18n="4">4</button>
+                                        <button type="button" class="btn btn-outline-primary" data-i18n="5+">5+</button>
+                                    </div>
+                                </div>
+                                <div class="col-lg-2 col-md-12">
+                                    <div class="d-grid gap-2">
+                                        <button class="btn btn-primary" id="apply-filters" data-i18n="apply">Piemērot</button>
+                                        <button class="btn btn-secondary" id="clear-filters" data-i18n="clear">Noskaidrot</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="active-filters my-3">
+                            <span id="filter-chips"></span>
+                            <span id="property-count" class="ms-2"></span>
+                        </div>
+                    </div>
+                </div>
+                <div id="property-grid" class="row row-cols-xl-3 row-cols-lg-2 row-cols-1">
+                    <div class="col mb-4" data-location="riga heritage lane" data-price="950000" data-bedrooms="4">
+                        <div class="card h-100">
+                            <img src="../image/dummy-img-900x700.jpg" class="card-img-top" alt="Sample Property" style="aspect-ratio: 3/2; object-fit: cover;">
+                            <div class="card-body d-flex flex-column">
+                                <div class="d-flex justify-content-between align-items-start mb-2">
+                                    <h5 class="card-title mb-0">Sample Property</h5>
+                                    <h6 class="text-accent fw-bold">$950,000</h6>
+                                </div>
+                                <div class="d-flex align-items-center mb-2">
+                                    <i class="rtmicon rtmicon-location me-2"></i>
+                                    <span class="text-muted">123 Heritage Lane, Riga</span>
+                                </div>
+                                <p class="card-text flex-grow-1">Elegant historic residence with modern amenities and refined finishes.</p>
+                                <div class="d-flex justify-content-between align-items-center mt-auto">
+                                    <div class="d-flex gap-3">
+                                        <span class="badge bg-light text-dark">4 bed</span>
+                                        <span class="badge bg-light text-dark">3 bath</span>
+                                    </div>
+                                    <a href="property_details.html" class="btn btn-accent btn-sm">
+                                        <span>View Details</span>
+                                        <i class="rtmicon rtmicon-arrow-up-right ms-1"></i>
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col mb-4" data-location="riga downtown" data-price="750000" data-bedrooms="3">
+                        <div class="card h-100">
+                            <img src="../image/dummy-img-900x600.jpg" class="card-img-top" alt="Modern Apartment" style="aspect-ratio: 3/2; object-fit: cover;">
+                            <div class="card-body d-flex flex-column">
+                                <div class="d-flex justify-content-between align-items-start mb-2">
+                                    <h5 class="card-title mb-0">Modern Apartment</h5>
+                                    <h6 class="text-accent fw-bold">$750,000</h6>
+                                </div>
+                                <div class="d-flex align-items-center mb-2">
+                                    <i class="rtmicon rtmicon-location me-2"></i>
+                                    <span class="text-muted">Downtown Riga</span>
+                                </div>
+                                <p class="card-text flex-grow-1">Contemporary living space with premium finishes and city views.</p>
+                                <div class="d-flex justify-content-between align-items-center mt-auto">
+                                    <div class="d-flex gap-3">
+                                        <span class="badge bg-light text-dark">3 bed</span>
+                                        <span class="badge bg-light text-dark">2 bath</span>
+                                    </div>
+                                    <a href="property_details.html" class="btn btn-accent btn-sm">
+                                        <span>View Details</span>
+                                        <i class="rtmicon rtmicon-arrow-up-right ms-1"></i>
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col mb-4" data-location="riga old town" data-price="1200000" data-bedrooms="5">
+                        <div class="card h-100">
+                            <img src="../image/dummy-img-600x400.jpg" class="card-img-top" alt="Historic Villa" style="aspect-ratio: 3/2; object-fit: cover;">
+                            <div class="card-body d-flex flex-column">
+                                <div class="d-flex justify-content-between align-items-start mb-2">
+                                    <h5 class="card-title mb-0">Historic Villa</h5>
+                                    <h6 class="text-accent fw-bold">$1,200,000</h6>
+                                </div>
+                                <div class="d-flex align-items-center mb-2">
+                                    <i class="rtmicon rtmicon-location me-2"></i>
+                                    <span class="text-muted">Old Town, Riga</span>
+                                </div>
+                                <p class="card-text flex-grow-1">Restored historic villa with original architectural details and modern conveniences.</p>
+                                <div class="d-flex justify-content-between align-items-center mt-auto">
+                                    <div class="d-flex gap-3">
+                                        <span class="badge bg-light text-dark">5 bed</span>
+                                        <span class="badge bg-light text-dark">4 bath</span>
+                                    </div>
+                                    <a href="property_details.html" class="btn btn-accent btn-sm">
+                                        <span>View Details</span>
+                                        <i class="rtmicon rtmicon-arrow-up-right ms-1"></i>
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col mb-4" data-location="riga suburbs" data-price="450000" data-bedrooms="2">
+                        <div class="card h-100">
+                            <img src="../image/dummy-img-600x600.jpg" class="card-img-top" alt="Cozy Townhouse" style="aspect-ratio: 3/2; object-fit: cover;">
+                            <div class="card-body d-flex flex-column">
+                                <div class="d-flex justify-content-between align-items-start mb-2">
+                                    <h5 class="card-title mb-0">Cozy Townhouse</h5>
+                                    <h6 class="text-accent fw-bold">$450,000</h6>
+                                </div>
+                                <div class="d-flex align-items-center mb-2">
+                                    <i class="rtmicon rtmicon-location me-2"></i>
+                                    <span class="text-muted">Riga Suburbs</span>
+                                </div>
+                                <p class="card-text flex-grow-1">Charming townhouse perfect for families, with garden and quiet neighborhood.</p>
+                                <div class="d-flex justify-content-between align-items-center mt-auto">
+                                    <div class="d-flex gap-3">
+                                        <span class="badge bg-light text-dark">2 bed</span>
+                                        <span class="badge bg-light text-dark">2 bath</span>
+                                    </div>
+                                    <a href="property_details.html" class="btn btn-accent btn-sm">
+                                        <span>View Details</span>
+                                        <i class="rtmicon rtmicon-arrow-up-right ms-1"></i>
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col mb-4" data-location="riga center" data-price="680000" data-bedrooms="3">
+                        <div class="card h-100">
+                            <img src="../image/dummy-img-900x500.jpg" class="card-img-top" alt="Luxury Penthouse" style="aspect-ratio: 3/2; object-fit: cover;">
+                            <div class="card-body d-flex flex-column">
+                                <div class="d-flex justify-content-between align-items-start mb-2">
+                                    <h5 class="card-title mb-0">Luxury Penthouse</h5>
+                                    <h6 class="text-accent fw-bold">$680,000</h6>
+                                </div>
+                                <div class="d-flex align-items-center mb-2">
+                                    <i class="rtmicon rtmicon-location me-2"></i>
+                                    <span class="text-muted">Riga Center</span>
+                                </div>
+                                <p class="card-text flex-grow-1">Stunning penthouse with panoramic city views and luxury amenities.</p>
+                                <div class="d-flex justify-content-between align-items-center mt-auto">
+                                    <div class="d-flex gap-3">
+                                        <span class="badge bg-light text-dark">3 bed</span>
+                                        <span class="badge bg-light text-dark">3 bath</span>
+                                    </div>
+                                    <a href="property_details.html" class="btn btn-accent btn-sm">
+                                        <span>View Details</span>
+                                        <i class="rtmicon rtmicon-arrow-up-right ms-1"></i>
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col mb-4" data-location="riga waterfront" data-price="890000" data-bedrooms="4">
+                        <div class="card h-100">
+                            <img src="../image/dummy-img-600x500.jpg" class="card-img-top" alt="Waterfront Residence" style="aspect-ratio: 3/2; object-fit: cover;">
+                            <div class="card-body d-flex flex-column">
+                                <div class="d-flex justify-content-between align-items-start mb-2">
+                                    <h5 class="card-title mb-0">Waterfront Residence</h5>
+                                    <h6 class="text-accent fw-bold">$890,000</h6>
+                                </div>
+                                <div class="d-flex align-items-center mb-2">
+                                    <i class="rtmicon rtmicon-location me-2"></i>
+                                    <span class="text-muted">Riga Waterfront</span>
+                                </div>
+                                <p class="card-text flex-grow-1">Beautiful waterfront property with private dock and stunning river views.</p>
+                                <div class="d-flex justify-content-between align-items-center mt-auto">
+                                    <div class="d-flex gap-3">
+                                        <span class="badge bg-light text-dark">4 bed</span>
+                                        <span class="badge bg-light text-dark">3 bath</span>
+                                    </div>
+                                    <a href="property_details.html" class="btn btn-accent btn-sm">
+                                        <span>View Details</span>
+                                        <i class="rtmicon rtmicon-arrow-up-right ms-1"></i>
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div id="empty-state" class="text-center py-5" style="display: none;">
+                    <h3 data-i18n="no_properties_found">Nekādas īpašības nav atrasti</h3>
+                    <p data-i18n="try_adjusting_filters_or">Mēģiniet pielāgot filtrus vai</p>
+                    <a href="#" id="clear-filters-link" class="link" data-i18n="clear_all_filters">Notīriet visus filtrus</a>
+                </div>
+            </div>
+        </div>
+
+        <div class="section bg-attach-cover" style="background-image: url(../image/bg_cta.png);">
+            <!-- Section How It Work -->
+            <div class="r-container d-flex flex-column" style="gap: 140px;">
+                <div class="d-flex flex-xl-row flex-column gap-5 justify-content-between align-items-center position-relative  scrollanimation animated fadeIn adr-7">
+                    <div class="devider-progress"></div>
+                    <div class="d-flex flex-column gap-5 align-items-center">
+                        <div class="icon-box active position-relative">
+                            <i class="rtmicon rtmicon-search"></i>
+                            <div class="position-absolute top-0 end-0 p-1 align-items-center text-center justify-content-center rounded-pill bg-black-1" style="width: 36px; height: 36px; margin-top: -15px; margin-right: -15px;">
+                                <h6 class="accent-primary m-0" data-i18n="1">1.</h6>
+                            </div>
+                        </div>
+                        <div class="d-flex flex-column text-center">
+                            <h4 data-i18n="explore_properties">Izpētiet īpašumus</h4>
+                            <p class="accent-color-4" style="max-width: 300px;" data-i18n="browse_curated_listings_and_find_a_space_that_truly_fits_your_needs">Pārlūkojiet veidotus sarakstus un atrodiet vietu, kas patiesi atbilst jūsu vajadzībām.</p>
+                        </div>
+                    </div>
+                    <div class="d-flex flex-column gap-5 align-items-center">
+                        <div class="icon-box position-relative">
+                            <i class="rtmicon rtmicon-client-happy"></i>
+                            <div class="position-absolute top-0 end-0 p-1 align-items-center text-center justify-content-center rounded-pill bg-black-1" style="width: 36px; height: 36px; margin-top: -15px; margin-right: -15px;">
+                                <h6 class="accent-primary m-0" data-i18n="2">2.</h6>
+                            </div>
+                        </div>
+                        <div class="d-flex flex-column text-center">
+                            <h4 data-i18n="connect_with_our_team">Sazinieties ar mūsu komandu</h4>
+                            <p class="accent-color-4" style="max-width: 300px;" data-i18n="receive_clear_practical_guidance_from_advisors_who_stay_with_you_through_the_entire_process">Saņemiet skaidrus, praktiskus norādījumus no padomniekiem, kuri paliek pie jums visā procesā.</p>
+                        </div>
+                    </div>
+                    <div class="d-flex flex-column gap-5 align-items-center">
+                        <div class="icon-box position-relative">
+                            <i class="rtmicon rtmicon-envelope-dollar"></i>
+                            <div class="position-absolute top-0 end-0 p-1 align-items-center text-center justify-content-center rounded-pill bg-black-1" style="width: 36px; height: 36px; margin-top: -15px; margin-right: -15px;">
+                                <h6 class="accent-primary m-0" data-i18n="3">3.</h6>
+                            </div>
+                        </div>
+                        <div class="d-flex flex-column text-center">
+                            <h4 data-i18n="seal_the_deal">Aizzīmogot darījumu</h4>
+                                <p class="accent-color-4" style="max-width: 300px;" data-i18n="move_through_negotiations_and_closing_with_confidence_and_care">Pārvietojieties sarunās un ar pārliecību un rūpību slēgšanu.</p>
+                        </div>
+                    </div>
+                </div>
+                <h4 class="text-center text-accent fst-italic  scrollanimation animated fadeInDown adr-7" data-i18n="from_exploring_listings_to_expert_advice_and_closing_vandore_heritage_guides_you_every_step_of_the_way">Sākot ar sarakstu izpēti un beidzot ar ekspertu padomiem un slēgšanu, Vandore Heritage vada jūs ik uz soļa.</h4>
+            </div>
+
+            <!-- Section CTA -->
+            <div class="r-container d-flex flex-column gap-3" style="margin-block: 6em;">
+                <div class="row row-cols-xl-2 row-cols-1 align-items-center">
+                    <div class="col col-xl-7 mb-3 scrollanimation animated fadeInLeft">
+                        <div class="d-flex flex-column gap-5 pe-xl-5">
+                            <h3 data-i18n="ready_to_find_your_next_home">Vai esat gatavs atrast savas nākamās mājas?</h3>
+                            <h6 data-i18n="leave_your_email">Atstājiet savu e -pastu</h6>
+                            <div class="d-flex flex-column gap-3">
+                                <div class="toast-container position-fixed bottom-0 end-0 p-3">
+                                    <div id="liveToast" class="toast success_msg_subscribe bg-dark-transparent text-white" role="alert" aria-live="assertive" aria-atomic="true">
+                                        <div class="d-flex">
+                                            <div class="toast-body" data-i18n="your_subscribe_send_successfully">
+                                                Jūsu abonēšana veiksmīgi nosūta!.
+                                            </div>
+                                            <button type="button" class="btn me-2 m-auto text-white" data-bs-dismiss="toast" aria-label="Close">
+                                                <i class="fa-solid fa-xmark"></i>
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div>
+                                    <form class="d-flex flex-column h-100 justify-content-center w-100 needs-validation form" novalidate="">
+                                        <input type="text" name="action" value="subscribe" hidden="">
+                                        <div class="input-group gap-3 mb-xl-2 mb-0 position-relative">
+                                            <input type="email" class="form-control rounded-0 mb-xl-0 mb-3 subscribe" placeholder="Join Our Newsletter" name="email" required="">
+                                            <button class="btn btn-accent submit_subscribe rounded-0 gap-2 px-4 py-3" type="submit"><i class="rtmicon rtmicon-arrow-right fw-bold"></i></button>
+                                            <div class="invalid-feedback text-white" data-i18n="please_enter_a_valid_email_eg_userexamplecom">
+                                                Lūdzu, ievadiet derīgu e -pastu (piemēram, user@example.com).
+                                            </div>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col col-xl-5 mb-3 scrollanimation animated fadeInRight">
+                        <img src="../image/dummy-img-900x600.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Vandore Heritage">
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    </main>
+
+    <footer>
+        <div class="section position-relative bg-black-1" style="height: 90vh;">
+            <div class="row row-cols-xl-2 row-cols-1 h-100">
+                <div class="col col-xl-8 mb-3">
+                    <div class="d-flex flex-column gap-3 justify-content-between h-100">
+                        <div class="d-flex flex-column accent-primary">
+                            <p class="gray" data-i18n="get_contact">Sazināties</p>
+                            <h1 class="fw-normal" data-i18n="infovandoreheritagelv">info@vandoreheritage.lv</h1>
+                        </div>
+                        <img src="../image/logo-footer.png?v=2025" alt="Vandore Heritage" class="img-fluid" width="938">
+                    </div>
+                </div>
+                <div class="col col-xl-4 mb-3">
+                    <div class="d-flex flex-column gap-5 justify-content-between accent-primary h-100">
+                        <div class="d-flex flex-row gap-5">
+                            <ul class="list-unstyled d-flex flex-column gap-3 accent-color">
+                                <li>
+                                    <a href="index.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="home">
+                                        Mājas
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="about.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="about">
+                                        Pret
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="properties.html" class="link active d-flex flex-row gap-3 align-items-center" data-i18n="properties">
+                                        Īpašības
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="rentals.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="rentals">
+                                        Īre
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="service.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="service">
+                                        Sakārtošana
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="contact.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="contact_us">
+                                        Sazinieties ar mums
+                                    </a>
+                                </li>
+                            </ul>
+                            <div class="d-flex flex-column gap-3">
+                                <a href="https://www.google.com/maps/place/Skanstes+iela+29A,+Vidzemes+priekšpilsēta,+Rīga,+LV-1013,+Latvia" class="link" target="_blank" data-i18n="skanstes_iela_29a91_rga_latvia">
+                                    Skanstes Iela 29A - 91, Rīga, Latvija
+                                </a>
+                                <a href="tel:+37129713030" class="link" data-i18n="371_29_71_3030">
+                                    +371 29 71 3030
+                                </a>
+                            </div>
+                        </div>
+                        <div class="d-flex flex-row gap-3">
+                            <div class="border-end pe-3 border-gray">
+                                <a href="" class="link d-flex flex-row gap-3 align-items-center" data-i18n="terms_conditions">
+                                    Noteikumi un nosacījumi
+                                </a>
+                            </div>
+                            <div>
+                                <a href="" class="link d-flex flex-row gap-3 align-items-center" data-i18n="privacy_notice">
+                                    Paziņojums par privātumu
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+
+    <!-- Back to top button -->
+    <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="rtmicon rtmicon-arrow-up"></i></a>
+
+    <!-- Scripts -->
+    <script src="../js/vendor/jquery.min.js"></script>
+    <script src="../js/vendor/bootstrap.bundle.min.js"></script>
+    <script src="../js/vendor/swiper-bundle.min.js"></script>
+    <script src="../js/script.js"></script>
+    <script src="../js/swiper-script.js"></script>
+    <script src="../js/submit-form.js"></script>
+    <script src="../js/vendor/isotope.pkgd.min.js"></script>
+    <script src="../js/video_embedded.js"></script>
+    <script src="../js/vendor/fslightbox.js"></script>
+    <script src="../js/custom.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.0/oyethemes_onscroll_animation.js"></script>
+
+
+
+</body></html>

--- a/_site/property-detail-template.html
+++ b/_site/property-detail-template.html
@@ -1,0 +1,366 @@
+<!DOCTYPE html><html lang="lv"><head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;600&family=Noto+Serif:wght@700&display=swap&subset=latin-ext" rel="stylesheet">
+    <link rel="stylesheet" href="../css/style.css">
+    <link rel="stylesheet" href="../css/custom.css">
+    <link rel="stylesheet" href="../css/fonts.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.2/animation_utility.css">
+    <link rel="icon" type="image/x-icon" href="../image/red_LOGO_Vandore.png?v=2025">
+    <title data-i18n="vandore_heritage_property_details" data-sb-field-path="title">Vandore Heritage - īpašuma informācija</title>
+</head>
+
+<body>
+    <!-- Header -->
+    <header class="bg-accent-primary px-5">
+        <nav class="navbar">
+            <div class="container-fluid ps-3 gap-3">
+                <div class="me-auto"></div>
+                <div class="logo-container position-absolute start-50 translate-middle-x" style="margin-top: 2cm;">
+                    <a class="navbar-brand" href="index.html"><img src="../image/red_LOGO_Vandore.png?v=2025" alt="Vandore Heritage" class="img-fluid"></a>
+                </div>
+                <div class="w-max-content" style="margin-top: 0.5cm;">
+                    <button class="btn btn-toggler-accent" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDark" aria-controls="offcanvasDark"><i class="fa-solid fa-bars"></i>
+                        Menu</button>
+
+                    <div class="offcanvas offcanvas-end offcanvas-fullwidth text-bg-dark" tabindex="-1" id="offcanvasDark" aria-labelledby="offcanvasRightLabel">
+                        <div class="offcanvas-header bg-transparent">
+                            <h5 id="offcanvasRightLabel">Menu</h5>
+                            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+                        </div>
+                        <div class="offcanvas-body">
+                            <div class="r-container">
+                                <div class="row row-cols-xl-2 row-cols-1">
+                                    <div class="col col-xl-10 mb-3">
+                                        <div class="d-flex flex-column">
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="01_homepage">01. Mājas lapa</span>
+                                                <img src="../image/img6.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="index.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="02_properties">02. Īpašumi</span>
+                                                <img src="../image/img5.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="properties.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="03_short_form_rentals">03. Īsas formas īre</span>
+                                                <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="rentals.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="04_about_us">04. Par mums</span>
+                                                <img src="../image/img33.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="about.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="05_services">05. Pakalpojumi</span>
+                                                <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="service.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="06_contact">06. Sazinieties</span>
+                                                <img src="../image/img29.png" class="img-fluid rounded-3 " style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="contact.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="07_news">07. Jaunumi</span>
+                                                <img src="../image/img26.png" class="img-fluid rounded-3 " style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="blog.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col col-xl-2 mb-3">
+                                        <div class="d-flex flex-column gap-5 accent-primary text-end">
+                                           <div class="d-flex flex-column gap-4">
+                                                <h6 data-i18n="riga_latvia">Rīga, Latvija</h6>
+                                                <div class="d-flex flex-column gap-3">
+                                                    <span data-i18n="skanstes_iela_29a91_rga_latvia">
+                                                        Skanstes Iela 29A - 91, Rīga, Latvija
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </nav>
+    </header>
+    <!-- End Header -->
+
+    <!-- Main -->
+    <main>
+        <!-- Banner -->
+        <div class="section position-relative bg-attach-cover">
+            <div class="r-container position-relative h-100">
+                <div class="position-absolute top-0 start-0 end-0 bottom-0 h-100 w-100" style="margin-top: 10rem;">
+                    <div class="row row-cols-2">
+                        <div class="col-3 col-xl-2"></div>
+                        <div class="col-9 col-xl-10">
+                            <img src="../{{BANNER_IMAGE}}" class="img-fluid custom-border rounded-2 w-100" alt="{{PROPERTY_TITLE}}">
+                        </div>
+                    </div>
+                </div>
+                <div class="d-flex flex-column gap-5 justify-content-between scrollanimation animated fadeInLeft adr-7 h-100 padding-custom">
+                    <div class="d-flex flex-column gap-2 h-100">
+                        <div><h1 class="display" data-i18n="property_title" data-sb-field-path="title">{{Property_Title}}</h1>
+                        <div class="row row-xl-cols-2 row-cols-1">
+                            <div class="col col-xl-2">
+                                <div class="d-flex flex-column gap-2 align-items-xl-center align-items-start">
+                                    <p data-i18n="property_location" data-sb-field-path="address">{{Property_location}}</p></div>
+                                    <div class="devider"></div>
+                                </div>
+                            </div>
+                            <div class="col col-xl-10"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Section Properties Details -->
+        <div class="section">
+            <div class="r-container d-flex flex-column gap-5">
+                <div class="row row-cols-xl-2 row-cols-1">
+                    <div class="col mb-3 scrollanimation animated fadeInLeft adr-7">
+                        <img src="../{{MAIN_IMAGE}}" class="img-fluid rounded-2 h-100" alt="{{PROPERTY_TITLE}}" data-sb-field-path="image#@src title#@alt">
+                    </div>
+                    <div class="col mb-3 scrollanimation animated fadeInDown adr-7">
+                        <!-- GALLERY_IMAGES_HERE -->
+                    </div>
+                </div>
+                <hr>
+                <div class="row row-cols-xl-2 row-cols-1">
+                    <div class="col col-xl-8 mb-3">
+                        <div class="d-flex flex-column gap-4 position-relative">
+                            <h4 data-i18n="description" data-sb-field-path="description">Apraksts</h4>
+                            {{DESCRIPTION}}
+                            <div class="row row-cols-xl-2 row-cols-1">
+                                <!-- VIDEO_PLAYER_HERE -->
+                                <div class="col mb-3">
+                                    <div class="d-flex flex-column gap-2">
+                                        <h4 data-i18n="property_specifications">Īpašuma specifikācijas </h4>
+                                        <div class="d-flex flex-row align-items-center font-2 gap-3">
+                                            <span data-i18n="property_type">Īpašuma veids:</span>
+                                            <h6 data-i18n="luxury_house">Luksusa māja</h6>
+                                        </div>
+                                        <div class="d-flex flex-row align-items-center font-2 gap-3">
+                                            <span data-i18n="bedrooms">Guļamistabas:</span>
+                                            <h6 data-i18n="bedrooms">{{Guļamistabas}}</h6>
+                                        </div>
+                                        <div class="d-flex flex-row align-items-center font-2 gap-3">
+                                            <span data-i18n="bathrooms">Vannas istabas:</span>
+                                            <h6 data-i18n="bathrooms">{{Vannas istabas}}</h6>
+                                        </div>
+                                        <div class="d-flex flex-row align-items-center font-2 gap-3">
+                                            <span data-i18n="building_area">Būvju zona:</span>
+                                            <h6 data-i18n="area_sq_ft">{{Area}} SQ pēdas</h6>
+                                        </div>
+                                        <div class="d-flex flex-row align-items-center font-2 gap-3">
+                                            <span data-i18n="floors">Grīdas:</span>
+                                            <h6 data-i18n="floors">{{Grīdas}}</h6>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <h4 data-i18n="additional_features">Papildu funkcijas</h4>
+                            <div class="d-flex flex-column gap-2">
+                                <!-- ADDITIONAL_FEATURES_HERE -->
+                            </div>
+                            <h4 data-i18n="property_location">Īpašuma vieta</h4>
+                            <div class="position-relative h-100">
+                                <iframe loading="lazy" class="maps" src="https://maps.google.com/maps?q=London%20Eye%2C%20London%2C%20United%20Kingdom&amp;t=m&amp;z=14&amp;output=embed&amp;iwloc=near" title="London Eye, London, United Kingdom" aria-label="London Eye, London, United Kingdom"></iframe>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col col-xl-4 mb-3">
+                        <div class="d-flex flex-column gap-4 ps-xl-3">
+                            <h4 class="m-0" data-i18n="latest_properties">Jaunākie īpašumi</h4>
+                            <hr class="m-0">
+                            <div class="d-flex flex-column gap-3">
+                                <img src="../image/dummy-img-600x400.jpg" class="img-fluid h-100 rounded-2" style="aspect-ratio: 3/2;" alt="Vandore Heritage">
+                                <a href="" data-sb-field-path="url#@href">
+                                    <div class="d-flex flex-column black-1">
+                                        <div class="d-flex flex-row justify-content-between">
+                                            <div class="d-flex flex-column gap-2">
+                                                <div class="d-flex flex-row gap-2 align-items-center">
+                                                    <i class="rtmicon rtmicon-location fw-bold"></i>
+                                                    <span data-i18n="beverly_hills_california">Beverlihils, Kalifornijā</span>
+                                                </div>
+                                            </div>
+                                            <h4 data-i18n="669k" data-sb-field-path="price">669 000 USD</h4>
+                                        </div>
+                                        <h4 data-i18n="sunset_valley_retreat">Saulrieta ielejas atkāpšanās</h4>
+                                    </div>
+                                </a>
+                            </div>
+                            <div class="d-flex flex-column gap-3">
+                                <img src="../image/dummy-img-600x400.jpg" class="img-fluid h-100 rounded-2" style="aspect-ratio: 3/2;" alt="Vandore Heritage">
+                                <a href="">
+                                    <div class="d-flex flex-column black-1">
+                                        <div class="d-flex flex-row justify-content-between">
+                                            <div class="d-flex flex-column gap-2">
+                                                <div class="d-flex flex-row gap-2 align-items-center">
+                                                    <i class="rtmicon rtmicon-location fw-bold"></i>
+                                                    <span data-i18n="beverly_hills_california">Beverlihils, Kalifornijā</span>
+                                                </div>
+                                            </div>
+                                            <h4 data-i18n="769k">769 000 USD</h4>
+                                        </div>
+                                        <h4 data-i18n="crystal_bay_residences">Crystal Bay dzīvesvietas</h4>
+                                    </div>
+                                </a>
+                            </div>
+                            <div class="d-flex flex-column gap-3">
+                                <img src="../image/dummy-img-600x400.jpg" class="img-fluid h-100 rounded-2" style="aspect-ratio: 3/2;" alt="Vandore Heritage">
+                                <a href="">
+                                    <div class="d-flex flex-column black-1">
+                                        <div class="d-flex flex-row justify-content-between">
+                                            <div class="d-flex flex-column gap-1">
+                                                <div class="d-flex flex-row gap-2 align-items-center">
+                                                    <i class="rtmicon rtmicon-location fw-bold"></i>
+                                                    <span data-i18n="beverly_hills_california">Beverlihils, Kalifornijā</span>
+                                                </div>
+                                            </div>
+                                            <h4 data-i18n="549k">USD 549K</h4>
+                                        </div>
+                                        <h4 data-i18n="harbor_bay_residences">Ostas līča dzīvesvietas</h4>
+                                    </div>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="modal fade bg-overlay" id="e119" tabindex="-1" aria-hidden="true">
+                <div class="modal-dialog modal-dialog-centered modal-xl">
+                    <div class="modal-content bg-dark-color">
+                        <iframe class="ifr-video" src="https://www.youtube.com/embed/FK2RaJ1EfA8?autoplay=1"></iframe>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    </main>
+
+    <footer>
+        <div class="section position-relative bg-black-1" style="height: 90vh;">
+            <div class="row row-cols-xl-2 row-cols-1 h-100">
+                <div class="col col-xl-8 mb-3">
+                    <div class="d-flex flex-column gap-3 justify-content-between h-100">
+                        <div class="d-flex flex-column accent-primary">
+                            <p class="gray" data-i18n="get_contact">Sazināties</p>
+                            <h1 class="fw-normal" data-i18n="infovandoreheritagelv">info@vandoreheritage.lv</h1>
+                        </div>
+                        <img src="../image/logo-footer.png?v=2025" alt="Vandore Heritage" class="img-fluid" width="938">
+                    </div>
+                </div>
+                <div class="col col-xl-4 mb-3">
+                    <div class="d-flex flex-column gap-5 justify-content-between accent-primary h-100">
+                        <div class="d-flex flex-row gap-5">
+                            <ul class="list-unstyled d-flex flex-column gap-3 accent-color">
+                                <li>
+                                    <a href="index.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="home">
+                                        Mājas
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="about.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="about">
+                                        Pret
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="properties.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="properties">
+                                        Īpašības
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="rentals.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="rentals">
+                                        Īre
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="service.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="service">
+                                        Sakārtošana
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="contact.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="contact_us">
+                                        Sazinieties ar mums
+                                    </a>
+                                </li>
+                            </ul>
+                            <div class="d-flex flex-column gap-3">
+                                <a href="https://www.google.com/maps/place/Skanstes+iela+29A,+Vidzemes+priekšpilsēta,+Rīga,+LV-1013,+Latvia" class="link" target="_blank" data-i18n="skanstes_iela_29a91_rga_latvia">
+                                    Skanstes Iela 29A - 91, Rīga, Latvija
+                                </a>
+                                <a href="tel:+37129713030" class="link" data-i18n="371_29_71_3030">
+                                    +371 29 71 3030
+                                </a>
+                            </div>
+                        </div>
+                        <div class="d-flex flex-row gap-3">
+                            <div class="border-end pe-3 border-gray">
+                                <a href="" class="link d-flex flex-row gap-3 align-items-center" data-i18n="terms_conditions">
+                                    Noteikumi un nosacījumi
+                                </a>
+                            </div>
+                            <div>
+                                <a href="" class="link d-flex flex-row gap-3 align-items-center" data-i18n="privacy_notice">
+                                    Paziņojums par privātumu
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+
+    <!-- Back to top button -->
+    <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="rtmicon rtmicon-arrow-up"></i></a>
+
+    <!-- Scripts -->
+    <script src="../js/vendor/jquery.min.js"></script>
+    <script src="../js/vendor/bootstrap.bundle.min.js"></script>
+    <script src="../js/vendor/swiper-bundle.min.js"></script>
+    <script src="../js/script.js"></script>
+    <script src="../js/swiper-script.js"></script>
+    <script src="../js/submit-form.js"></script>
+    <script src="../js/vendor/isotope.pkgd.min.js"></script>
+    <script src="../js/video_embedded.js"></script>
+    <script src="../js/vendor/fslightbox.js"></script>
+    <script src="../js/custom.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.0/oyethemes_onscroll_animation.js"></script>
+
+
+
+</body></html>

--- a/_site/property-detail/index.html
+++ b/_site/property-detail/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Property Detail</title>
+    <link rel="stylesheet" href="/css/style.css">
+  </head>
+  <body>
+    <header>
+      <nav>
+        <a href="/index.html">Home</a>
+        <a href="/properties.html">Properties</a>
+      </nav>
+    </header>
+
+    <main>
+      
+      
+      
+        
+          
+        
+      
+
+      
+        <article>
+          <h1>Sample Apartment</h1>
+          <p><strong>Price:</strong> €120,000</p>
+          <p><strong>Address:</strong> Example St 10, Riga</p>
+          <p>Cozy 2-bedroom apartment in the city center.</p>
+          
+            <img alt="Property image" src="/image/property/property_1.jpg" style="max-width: 600px; width: 100%; height: auto;"/>
+          
+        </article>
+      
+    </main>
+  </body>
+  </html>
+

--- a/_site/property_details.html
+++ b/_site/property_details.html
@@ -1,0 +1,427 @@
+<!DOCTYPE html><html lang="lv" data-sb-object-id="content/pages/property_details.json"><head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;600&family=Noto+Serif:wght@700&display=swap&subset=latin-ext" rel="stylesheet">
+    <link rel="stylesheet" href="../css/style.css">
+    <link rel="stylesheet" href="../css/custom.css">
+    <link rel="stylesheet" href="../css/fonts.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.2/animation_utility.css">
+    <link rel="icon" type="image/x-icon" href="../image/red_LOGO_Vandore.png?v=2025">
+    <title data-i18n="vandore_heritage_property_details" data-sb-field-path="title">Vandore Heritage - īpašuma informācija</title>
+</head>
+
+<body>
+    <!-- Header -->
+    <header class="bg-accent-primary px-5">
+        <nav class="navbar">
+            <div class="container-fluid ps-3 gap-3">
+                <div class="me-auto"></div>
+                <div class="logo-container position-absolute start-50 translate-middle-x" style="margin-top: 2cm;">
+                    <a class="navbar-brand" href="index.html"><img src="../image/red_LOGO_Vandore.png?v=2025" alt="Vandore Heritage" class="img-fluid"></a>
+                </div>
+                <div class="w-max-content" style="margin-top: 0.5cm;">
+                    <button class="btn btn-toggler-accent" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDark" aria-controls="offcanvasDark"><i class="fa-solid fa-bars"></i>
+                        Menu</button>
+
+                    <div class="offcanvas offcanvas-end offcanvas-fullwidth text-bg-dark" tabindex="-1" id="offcanvasDark" aria-labelledby="offcanvasRightLabel">
+                        <div class="offcanvas-header bg-transparent">
+                            <h5 id="offcanvasRightLabel">Menu</h5>
+                            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+                        </div>
+                        <div class="offcanvas-body">
+                            <div class="r-container">
+                                <div class="row row-cols-xl-2 row-cols-1">
+                                    <div class="col col-xl-10 mb-3">
+                                        <div class="d-flex flex-column">
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="01_homepage">01. Mājas lapa</span>
+                                                <img src="../image/img6.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="index.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="02_properties">02. Īpašumi</span>
+                                                <img src="../image/img5.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="properties.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="03_short_form_rentals">03. Īsas formas īre</span>
+                                                <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="rentals.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="04_about_us">04. Par mums</span>
+                                                <img src="../image/img33.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="about.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="05_services">05. Pakalpojumi</span>
+                                                <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="service.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="06_contact">06. Sazinieties</span>
+                                                <img src="../image/img29.png" class="img-fluid rounded-3 " style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="contact.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="07_news">07. Jaunumi</span>
+                                                <img src="../image/img26.png" class="img-fluid rounded-3 " style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="blog.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col col-xl-2 mb-3">
+                                        <div class="d-flex flex-column gap-5 accent-primary text-end">
+                                           <div class="d-flex flex-column gap-4">
+                                                <h6 data-i18n="riga_latvia">Rīga, Latvija</h6>
+                                                <div class="d-flex flex-column gap-3">
+                                                    <span data-i18n="skanstes_iela_29a91_rga_latvia">
+                                                        Skanstes Iela 29A - 91, Rīga, Latvija
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </nav>
+    </header>
+    <!-- End Header -->
+
+    <!-- Main -->
+    <main>
+        <!-- Banner -->
+        <div class="section position-relative bg-attach-cover">
+            <div class="r-container position-relative h-100">
+                <div class="position-absolute top-0 start-0 end-0 bottom-0 h-100 w-100" style="margin-top: 10rem;">
+                    <div class="row row-cols-2">
+                        <div class="col-3 col-xl-2"></div>
+                        <div class="col-9 col-xl-10">
+                            <img src="../image/dummy-img-1920x900.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Vandore Heritage">
+                        </div>
+                    </div>
+                </div>
+                <div class="d-flex flex-column gap-5 justify-content-between scrollanimation animated fadeInLeft adr-7 h-100 padding-custom">
+                    <div class="d-flex flex-column gap-2 h-100">
+                        <div><h1 class="display" data-i18n="luxury_home_advisors" data-sb-field-path="heroHeading">Luksusa mājas konsultanti</h1>
+                        <div class="row row-xl-cols-2 row-cols-1">
+                            <div class="col col-xl-2">
+                                <div class="d-flex flex-column gap-2 align-items-xl-center align-items-start">
+                                    <p data-i18n="luxury_home_advisors_specialize_in_guiding_clients_through_buying_and_selling_highend_properties" data-sb-field-path="heroSubheading">Luksusa mājas konsultanti specializējas klientu vadīšanā, pērkot un pārdodot 
+augstākās klases īpašības.</p></div>
+                                    <div class="devider"></div>
+                                </div>
+                            </div>
+                            <div class="col col-xl-10"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Section Properties Details -->
+        <div class="section">
+            <div class="r-container d-flex flex-column gap-5">
+                <div class="row row-cols-xl-2 row-cols-1">
+                    <div class="col mb-3 scrollanimation animated fadeInLeft adr-7">
+                        <img src="../image/dummy-img-900x700.jpg" class="img-fluid rounded-2 h-100" alt="Vandore Heritage">
+                    </div>
+                    <div class="col mb-3 scrollanimation animated fadeInDown adr-7">
+                        <div class="d-flex flex-column gap-4">
+                            <img src="../image/dummy-img-900x600.jpg" class="img-fluid rounded-2 h-100" alt="Vandore Heritage">
+                            <div class="row row-cols-xl-2 row-cols-1">
+                                <div class="col mb-xl-0 mb-3">
+                                    <img src="../image/dummy-img-600x600.jpg" class="img-fluid rounded-2 h-100" style="aspect-ratio: 1/1;" alt="Vandore Heritage">
+                                </div>
+                                <div class="col mb-xl-0 mb-3">
+                                    <img src="../image/dummy-img-600x600.jpg" class="img-fluid rounded-2 h-100" style="aspect-ratio: 1/1;" alt="Vandore Heritage">
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <hr>
+                <div class="row row-cols-xl-2 row-cols-1">
+                    <div class="col col-xl-8 mb-3">
+                        <div class="d-flex flex-column gap-4 position-relative">
+                            <h4 data-i18n="description">Apraksts</h4>
+                            <p data-i18n="our_luxury_home_advisors_specialize_in_providing_personalized_professional_advice_to_help_you_find_the_perfect_luxury_property_whether_youre_searching_for_a_dream_home_a_vacation_estate_or_an_investment_property_our_team_brings_years_of_expertise_to_the_table_we_take_the_time_to_understand_your_unique_needs_and_preferences_ensuring_that_every_step_of_the_process_is_smooth_efficient_and_rewarding_from_selecting_prime_locations_to_negotiating_the_best_deals_we_offer_exclusive_insights_and_unmatched_service_to_guide_you_through_the_luxury_real_estate_market">
+                                Mūsu luksusa mājas konsultanti specializējas personalizētu, profesionālu padomu sniegšanā 
+Palīdziet jums atrast perfektu luksusa īpašumu. Vai meklējat sapņu māju, a 
+atvaļinājuma īpašums vai investīciju īpašums, mūsu komanda sniedz gadu kompetenci 
+galds. Mēs veltām laiku, lai izprastu jūsu unikālās vajadzības un vēlmes, to nodrošinot 
+Katrs procesa solis ir gluds, efektīvs un atalgojošs. Izvēloties Prime 
+Vietas, lai sarunātos par labākajiem piedāvājumiem, mēs piedāvājam ekskluzīvas atziņas un nepārspējamās 
+pakalpojums, lai palīdzētu jums caur luksusa nekustamā īpašuma tirgu.
+                            </p>
+                            <div class="row row-cols-xl-2 row-cols-1">
+                                <div class="col mb-3">
+                                    <div class="overflow-hidden" style="object-fit: cover;">
+                                        <div class="position-relative h-100 overflow-hidden">
+                                            <div class="position-absolute start-0 top-0 w-100 h-100" style="z-index: 2;">
+                                                <div class="d-flex justify-content-center align-items-center h-100">
+                                                    <button type="button" class="request-loader" data-bs-toggle="modal" data-bs-target="#e119">
+                                                        <i class="fa-solid fa-play ms-1"></i>
+                                                    </button>
+                                                </div>
+                                            </div>
+                                            <img src="../image/dummy-img-600x400.jpg" class="img-fluid rounded-2 w-100" style="aspect-ratio: 3/2;" alt="Vandore Heritage">
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col mb-3">
+                                    <div class="d-flex flex-column gap-2">
+                                        <h4 data-i18n="property_specifications">Īpašuma specifikācijas </h4>
+                                        <div class="d-flex flex-row align-items-center font-2 gap-3">
+                                            <span data-i18n="property_type">Īpašuma veids:</span>
+                                            <h6 data-i18n="luxury_house">Luksusa māja</h6>
+                                        </div>
+                                        <div class="d-flex flex-row align-items-center font-2 gap-3">
+                                            <span data-i18n="bedrooms">Guļamistabas:</span>
+                                            <h6 data-i18n="4">4</h6>
+                                        </div>
+                                        <div class="d-flex flex-row align-items-center font-2 gap-3">
+                                            <span data-i18n="bathrooms">Vannas istabas:</span>
+                                            <h6 data-i18n="5">5</h6>
+                                        </div>
+                                        <div class="d-flex flex-row align-items-center font-2 gap-3">
+                                            <span data-i18n="building_area">Būvju zona:</span>
+                                            <h6 data-i18n="3500_sq_ft">3500 kv pēdas</h6>
+                                        </div>
+                                        <div class="d-flex flex-row align-items-center font-2 gap-3">
+                                            <span data-i18n="land_area">Zemes zona:</span>
+                                            <h6 data-i18n="5000_sq_ft">5000 kvadrātpēdas</h6>
+                                        </div>
+                                        <div class="d-flex flex-row align-items-center font-2 gap-3">
+                                            <span data-i18n="floors">Grīdas:</span>
+                                            <h6 data-i18n="2">Rādītājs</h6>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <h4 data-i18n="additional_features">Papildu funkcijas</h4>
+                            <p class="m-0" data-i18n="whether_youre_searching_for_a_dream_home_a_vacation_estate_or_an_investment_property_our_team_brings_years_of_expertise_to_the_table_we_take_the_time_to_understand_your_unique_needs_and_preferences_ensuring_that_every_step_of_the_process_is_smooth_efficient_and_rewarding">
+                                Neatkarīgi no tā, vai meklējat sapņu māju, brīvdienu īpašumu vai ieguldījumu īpašumu, 
+Mūsu komanda sniedz galdam gadu kompetenci. Mēs veltām laiku, lai saprastu jūsu 
+unikālas vajadzības un vēlmes, nodrošinot, ka katrs procesa posms ir vienmērīgs, 
+efektīvs un atalgojošs.
+                            </p>
+                            <div class="d-flex flex-column gap-2">
+                                <div class="d-flex flex-row align-items-center font-2 gap-3">
+                                    <i class="rtmicon rtmicon-arrow-up-right fs-5"></i>
+                                    <span class="text-color-2" data-i18n="virtual_tour_or_3d_walkthrough">Virtuālā tūre vai 3D gājiens</span>
+                                </div>
+                                <div class="d-flex flex-row align-items-center font-2 gap-3">
+                                    <i class="rtmicon rtmicon-arrow-up-right fs-5"></i>
+                                    <span class="text-color-2" data-i18n="ar_augmented_reality_feature">AR (papildinātā realitāte) funkcija</span>
+                                </div>
+                                <div class="d-flex flex-row align-items-center font-2 gap-3">
+                                    <i class="rtmicon rtmicon-arrow-up-right fs-5"></i>
+                                    <span class="text-color-2" data-i18n="home_cinema_room">Mājas kino istaba</span>
+                                </div>
+                                <div class="d-flex flex-row align-items-center font-2 gap-3">
+                                    <i class="rtmicon rtmicon-arrow-up-right fs-5"></i>
+                                    <span class="text-color-2" data-i18n="secure_parking_for_up_to_5_vehicles">Droša autostāvvieta līdz 5 transportlīdzekļiem</span>
+                                </div>
+                                <div class="d-flex flex-row align-items-center font-2 gap-3">
+                                    <i class="rtmicon rtmicon-arrow-up-right fs-5"></i>
+                                    <span class="text-color-2" data-i18n="247_security_and_concierge_services">24/7 drošības un konsjerža pakalpojumi</span>
+                                </div>
+                            </div>
+                            <h4 data-i18n="property_location">Īpašuma vieta</h4>
+                            <div class="position-relative h-100">
+                                <iframe loading="lazy" class="maps" src="https://maps.google.com/maps?q=London%20Eye%2C%20London%2C%20United%20Kingdom&amp;t=m&amp;z=14&amp;output=embed&amp;iwloc=near" title="London Eye, London, United Kingdom" aria-label="London Eye, London, United Kingdom"></iframe>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col col-xl-4 mb-3">
+                        <div class="d-flex flex-column gap-4 ps-xl-3">
+                            <h4 class="m-0" data-i18n="latest_properties">Jaunākie īpašumi</h4>
+                            <hr class="m-0">
+                            <div class="d-flex flex-column gap-3">
+                                <img src="../image/dummy-img-600x400.jpg" class="img-fluid h-100 rounded-2" style="aspect-ratio: 3/2;" alt="Vandore Heritage">
+                                <a href="">
+                                    <div class="d-flex flex-column black-1">
+                                        <div class="d-flex flex-row justify-content-between">
+                                            <div class="d-flex flex-column gap-2">
+                                                <div class="d-flex flex-row gap-2 align-items-center">
+                                                    <i class="rtmicon rtmicon-location fw-bold"></i>
+                                                    <span data-i18n="beverly_hills_california">Beverlihils, Kalifornijā</span>
+                                                </div>
+                                            </div>
+                                            <h4 data-i18n="669k">669 000 USD</h4>
+                                        </div>
+                                        <h4 data-i18n="sunset_valley_retreat">Saulrieta ielejas atkāpšanās</h4>
+                                    </div>
+                                </a>
+                            </div>
+                            <div class="d-flex flex-column gap-3">
+                                <img src="../image/dummy-img-600x400.jpg" class="img-fluid h-100 rounded-2" style="aspect-ratio: 3/2;" alt="Vandore Heritage">
+                                <a href="">
+                                    <div class="d-flex flex-column black-1">
+                                        <div class="d-flex flex-row justify-content-between">
+                                            <div class="d-flex flex-column gap-2">
+                                                <div class="d-flex flex-row gap-2 align-items-center">
+                                                    <i class="rtmicon rtmicon-location fw-bold"></i>
+                                                    <span data-i18n="beverly_hills_california">Beverlihils, Kalifornijā</span>
+                                                </div>
+                                            </div>
+                                            <h4 data-i18n="769k">769 000 USD</h4>
+                                        </div>
+                                        <h4 data-i18n="crystal_bay_residences">Crystal Bay dzīvesvietas</h4>
+                                    </div>
+                                </a>
+                            </div>
+                            <div class="d-flex flex-column gap-3">
+                                <img src="../image/dummy-img-600x400.jpg" class="img-fluid h-100 rounded-2" style="aspect-ratio: 3/2;" alt="Vandore Heritage">
+                                <a href="">
+                                    <div class="d-flex flex-column black-1">
+                                        <div class="d-flex flex-row justify-content-between">
+                                            <div class="d-flex flex-column gap-1">
+                                                <div class="d-flex flex-row gap-2 align-items-center">
+                                                    <i class="rtmicon rtmicon-location fw-bold"></i>
+                                                    <span data-i18n="beverly_hills_california">Beverlihils, Kalifornijā</span>
+                                                </div>
+                                            </div>
+                                            <h4 data-i18n="549k">USD 549K</h4>
+                                        </div>
+                                        <h4 data-i18n="harbor_bay_residences">Ostas līča dzīvesvietas</h4>
+                                    </div>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="modal fade bg-overlay" id="e119" tabindex="-1" aria-hidden="true">
+                <div class="modal-dialog modal-dialog-centered modal-xl">
+                    <div class="modal-content bg-dark-color">
+                        <iframe class="ifr-video" src="https://www.youtube.com/embed/FK2RaJ1EfA8?autoplay=1"></iframe>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    </main>
+
+    <footer>
+        <div class="section position-relative bg-black-1" style="height: 90vh;">
+            <div class="row row-cols-xl-2 row-cols-1 h-100">
+                <div class="col col-xl-8 mb-3">
+                    <div class="d-flex flex-column gap-3 justify-content-between h-100">
+                        <div class="d-flex flex-column accent-primary">
+                            <p class="gray" data-i18n="get_contact">Sazināties</p>
+                            <h1 class="fw-normal" data-i18n="infovandoreheritagelv">info@vandoreheritage.lv</h1>
+                        </div>
+                        <img src="../image/logo-footer.png?v=2025" alt="Vandore Heritage" class="img-fluid" width="938">
+                    </div>
+                </div>
+                <div class="col col-xl-4 mb-3">
+                    <div class="d-flex flex-column gap-5 justify-content-between accent-primary h-100">
+                        <div class="d-flex flex-row gap-5">
+                            <ul class="list-unstyled d-flex flex-column gap-3 accent-color">
+                                <li>
+                                    <a href="index.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="home">
+                                        Mājas
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="about.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="about">
+                                        Pret
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="properties.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="properties">
+                                        Īpašības
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="rentals.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="rentals">
+                                        Īre
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="service.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="service">
+                                        Sakārtošana
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="contact.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="contact_us">
+                                        Sazinieties ar mums
+                                    </a>
+                                </li>
+                            </ul>
+                            <div class="d-flex flex-column gap-3">
+                                <a href="https://www.google.com/maps/place/Skanstes+iela+29A,+Vidzemes+priekšpilsēta,+Rīga,+LV-1013,+Latvia" class="link" target="_blank" data-i18n="skanstes_iela_29a91_rga_latvia">
+                                    Skanstes Iela 29A - 91, Rīga, Latvija
+                                </a>
+                                <a href="tel:+37129713030" class="link" data-i18n="371_29_71_3030">
+                                    +371 29 71 3030
+                                </a>
+                            </div>
+                        </div>
+                        <div class="d-flex flex-row gap-3">
+                            <div class="border-end pe-3 border-gray">
+                                <a href="" class="link d-flex flex-row gap-3 align-items-center" data-i18n="terms_conditions">
+                                    Noteikumi un nosacījumi
+                                </a>
+                            </div>
+                            <div>
+                                <a href="" class="link d-flex flex-row gap-3 align-items-center" data-i18n="privacy_notice">
+                                    Paziņojums par privātumu
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+
+    <!-- Back to top button -->
+    <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="rtmicon rtmicon-arrow-up"></i></a>
+
+    <!-- Scripts -->
+    <script src="../js/vendor/jquery.min.js"></script>
+    <script src="../js/vendor/bootstrap.bundle.min.js"></script>
+    <script src="../js/vendor/swiper-bundle.min.js"></script>
+    <script src="../js/script.js"></script>
+    <script src="../js/swiper-script.js"></script>
+    <script src="../js/submit-form.js"></script>
+    <script src="../js/vendor/isotope.pkgd.min.js"></script>
+    <script src="../js/video_embedded.js"></script>
+    <script src="../js/vendor/fslightbox.js"></script>
+    <script src="../js/custom.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.0/oyethemes_onscroll_animation.js"></script>
+
+
+
+</body></html>

--- a/_site/rentals.html
+++ b/_site/rentals.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html lang="lv" data-sb-object-id="content/pages/rentals.json">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;600&family=Noto+Serif:wght@700&display=swap&subset=latin-ext" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+  <link rel="stylesheet" href="../css/changes.css">
+  <link rel="stylesheet" href="../css/custom.css">
+  <link rel="stylesheet" href="../css/fonts.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.2/animation_utility.css">
+  <link rel="icon" type="image/x-icon" href="../image/red_LOGO_Vandore.png?v=2025">
+  <title data-i18n="vandore_heritage_our_rentals" data-sb-field-path="title">Vandore Heritage — Īre un īstermiņa īre</title>
+</head>
+
+<body>
+  <!-- Header -->
+  <header class="bg-accent-primary px-5">
+    <nav class="navbar">
+      <div class="container-fluid ps-3 gap-3">
+        <div class="me-auto"></div>
+        <div class="logo-container position-absolute start-50 translate-middle-x" style="margin-top: 2cm;">
+          <a class="navbar-brand" href="index.html"><img src="../image/red_LOGO_Vandore.png?v=2025" alt="Vandore Heritage" class="img-fluid"></a>
+        </div>
+        <div class="w-max-content" style="margin-top: 0.5cm;">
+          <button class="btn btn-toggler-accent" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDark" aria-controls="offcanvasDark">
+            <i class="fa-solid fa-bars"></i> Izvēlne
+          </button>
+          <div class="offcanvas offcanvas-end offcanvas-fullwidth text-bg-dark" tabindex="-1" id="offcanvasDark" aria-labelledby="offcanvasRightLabel">
+            <div class="offcanvas-header bg-transparent">
+              <h5 id="offcanvasRightLabel">Izvēlne</h5>
+              <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Aizvērt"></button>
+            </div>
+            <div class="offcanvas-body">
+              <div class="r-container">
+                <div class="row row-cols-xl-2 row-cols-1">
+                  <div class="col col-xl-10 mb-3">
+                    <div class="d-flex flex-column">
+                      <div class="navigation">
+                        <span class="header-text" data-i18n="01_homepage">01. Mājas lapa</span>
+                        <img src="../image/img6.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Mājas lapa">
+                        <a href="index.html" class="d-flex" style="justify-self: end;"><i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i></a>
+                      </div>
+                      <hr>
+                      <div class="navigation">
+                        <span class="header-text" data-i18n="02_properties">02. Īpašumi</span>
+                        <img src="../image/img5.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Īpašumi">
+                        <a href="properties.html" class="d-flex" style="justify-self: end;"><i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i></a>
+                      </div>
+                      <hr>
+                      <div class="navigation">
+                        <span class="header-text" data-i18n="03_short_form_rentals">03. Īstermiņa īre</span>
+                        <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Īstermiņa īre">
+                        <a href="rentals.html" class="d-flex" style="justify-self: end;"><i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i></a>
+                      </div>
+                      <hr>
+                      <div class="navigation">
+                        <span class="header-text" data-i18n="04_about_us">04. Par mums</span>
+                        <img src="../image/img33.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Par mums">
+                        <a href="about.html" class="d-flex" style="justify-self: end;"><i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i></a>
+                      </div>
+                      <hr>
+                      <div class="navigation">
+                        <span class="header-text" data-i18n="05_services">05. Pakalpojumi</span>
+                        <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Pakalpojumi">
+                        <a href="service.html" class="d-flex" style="justify-self: end;"><i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i></a>
+                      </div>
+                      <hr>
+                      <div class="navigation">
+                        <span class="header-text" data-i18n="06_contact">06. Sazinieties</span>
+                        <img src="../image/img29.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Sazinieties">
+                        <a href="contact.html" class="d-flex" style="justify-self: end;"><i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i></a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="col col-xl-2 mb-3">
+                    <div class="d-flex flex-column gap-5 accent-primary text-end">
+                      <div class="d-flex flex-column gap-4">
+                        <h6>Rīga, Latvija</h6>
+                        <div class="d-flex flex-column gap-3">
+                          <span>Skanstes iela 29A - 91, Rīga, Latvija</span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </nav>
+  </header>
+  <!-- End Header -->
+
+  <!-- Main -->
+  <main>
+    <!-- Hero -->
+    <section class="section pt-5 pb-3">
+      <div class="r-container">
+        <div class="row">
+          <div class="col-12">
+            <h1 class="fw-normal" data-i18n="rentals_heading">Īre un īstermiņa īre</h1>
+            <p class="gray" data-i18n="rentals_subheading">Atrodiet piemērotu mājokli ilgtermiņa vai īstermiņa īrei visā Latvijā.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Filters -->
+    <section class="section pt-0 pb-4">
+      <div class="r-container">
+        <div class="filter-bar card p-4">
+          <div class="row g-3 align-items-end">
+            <div class="col-12 col-md-4">
+              <label for="location" class="form-label" data-i18n="location">Atrašanās vieta</label>
+              <input id="location" type="text" class="form-control" placeholder="Pilsēta / rajons / apkaime">
+            </div>
+            <div class="col-6 col-md-2">
+              <label for="price-min" class="form-label" data-i18n="min_price">Min. cena (€)</label>
+              <input id="price-min" type="number" class="form-control" placeholder="0">
+            </div>
+            <div class="col-6 col-md-2">
+              <label for="price-max" class="form-label" data-i18n="max_price">Maks. cena (€)</label>
+              <input id="price-max" type="number" class="form-control" placeholder="1000">
+            </div>
+            <div class="col-6 col-md-2">
+              <label for="bedrooms" class="form-label" data-i18n="bedrooms">Guļamistabas</label>
+              <select id="bedrooms" class="form-select">
+                <option value="" data-i18n="all">Visas</option>
+                <option>1</option>
+                <option>2</option>
+                <option>3+</option>
+              </select>
+            </div>
+            <div class="col-6 col-md-2">
+              <label for="rent-type" class="form-label" data-i18n="rent_type">Īres tips</label>
+              <select id="rent-type" class="form-select">
+                <option value="long" data-i18n="long_term">Ilgtermiņa</option>
+                <option value="short" data-i18n="short_term">Īstermiņa</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="active-filters my-2">
+          <span id="rentals-count"></span>
+        </div>
+      </div>
+    </section>
+
+    <!-- Listings -->
+    <section class="section pt-0 pb-5">
+      <div class="r-container">
+        <div id="rentals-grid" class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4">
+          <div class="col" data-location="riga centrs" data-price="650" data-bedrooms="2" data-type="long">
+            <div class="card h-100">
+              <img src="../image/dummy-img-600x400.jpg" class="card-img-top" alt="Divistabu dzīvoklis centrā">
+              <div class="card-body d-flex flex-column">
+                <div class="d-flex justify-content-between align-items-center mb-2">
+                  <h5 class="card-title mb-0">Divistabu dzīvoklis centrā</h5>
+                  <span class="badge bg-primary">Īre</span>
+                </div>
+                <p class="card-text gray">Rīga, Centrs · 650 €/mēn</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="col" data-location="jurmala" data-price="120" data-bedrooms="3" data-type="short">
+            <div class="card h-100">
+              <img src="../image/dummy-img-600x400.jpg" class="card-img-top" alt="Māja pie jūras">
+              <div class="card-body d-flex flex-column">
+                <div class="d-flex justify-content-between align-items-center mb-2">
+                  <h5 class="card-title mb-0">Māja pie jūras</h5>
+                  <span class="badge bg-success">Īstermiņa</span>
+                </div>
+                <p class="card-text gray">Jūrmala · no 120 €/nakts</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="col" data-location="liepaja" data-price="420" data-bedrooms="1" data-type="long">
+            <div class="card h-100">
+              <img src="../image/dummy-img-600x400.jpg" class="card-img-top" alt="Studijas tipa dzīvoklis">
+              <div class="card-body d-flex flex-column">
+                <div class="d-flex justify-content-between align-items-center mb-2">
+                  <h5 class="card-title mb-0">Studijas tipa dzīvoklis</h5>
+                  <span class="badge bg-primary">Īre</span>
+                </div>
+                <p class="card-text gray">Liepāja · 420 €/mēn</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <!-- Footer -->
+  <footer>
+    <div class="section position-relative bg-black-1" style="height: 90vh;">
+      <div class="row row-cols-xl-2 row-cols-1 h-100">
+        <div class="col col-xl-8 mb-3">
+          <div class="d-flex flex-column gap-3 justify-content-between h-100">
+            <div class="d-flex flex-column accent-primary">
+              <p class="gray" data-i18n="get_contact">Sazināties</p>
+              <h1 class="fw-normal" data-i18n="infovandoreheritagelv">info@vandoreheritage.lv</h1>
+            </div>
+            <img src="../image/logo-footer.png?v=2025" alt="Vandore Heritage" class="img-fluid" width="938">
+          </div>
+        </div>
+        <div class="col col-xl-4 mb-3">
+          <div class="d-flex flex-column gap-5 justify-content-between accent-primary h-100">
+            <div class="d-flex flex-row gap-5">
+              <ul class="list-unstyled d-flex flex-column gap-3 accent-color">
+                <li><a href="index.html" class="link active d-flex flex-row gap-3 align-items-center" data-i18n="home">Mājas</a></li>
+                <li><a href="about.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="about">Par mums</a></li>
+                <li><a href="properties.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="properties">Īpašumi</a></li>
+                <li><a href="rentals.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="rentals">Īre</a></li>
+                <li><a href="service.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="service">Pakalpojumi</a></li>
+                <li><a href="contact.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="contact_us">Sazinieties ar mums</a></li>
+              </ul>
+              <div class="d-flex flex-column gap-3">
+                <a href="https://www.google.com/maps/place/Skanstes+iela+29A,+Rīga,+LV-1013,+Latvia" class="link" target="_blank">
+                  Skanstes iela 29A - 91, Rīga, Latvija
+                </a>
+                <a href="tel:+37129713030" class="link">+371 29 71 3030</a>
+              </div>
+            </div>
+            <div class="d-flex flex-row gap-3">
+              <div class="border-end pe-3 border-gray">
+                <a href="#" class="link d-flex flex-row gap-3 align-items-center" data-i18n="terms_conditions">Noteikumi un nosacījumi</a>
+              </div>
+              <div>
+                <a href="#" class="link d-flex flex-row gap-3 align-items-center" data-i18n="privacy_notice">Privātuma paziņojums</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <!-- Back to top button -->
+  <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="rtmicon rtmicon-arrow-up"></i></a>
+
+  <!-- Scripts -->
+  <script src="../js/vendor/jquery.min.js"></script>
+  <script src="../js/vendor/bootstrap.bundle.min.js"></script>
+  <script src="../js/vendor/swiper-bundle.min.js"></script>
+  <script src="../js/script.js"></script>
+  <script src="../js/swiper-script.js"></script>
+  <script src="../js/submit-form.js"></script>
+  <script src="../js/vendor/isotope.pkgd.min.js"></script>
+  <script src="../js/video_embedded.js"></script>
+  <script src="../js/custom.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.0/oyethemes_onscroll_animation.js"></script>
+
+</body>
+</html>

--- a/_site/service.html
+++ b/_site/service.html
@@ -1,0 +1,582 @@
+<!DOCTYPE html><html lang="lv" data-sb-object-id="content/pages/service.json"><head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;600&family=Noto+Serif:wght@700&display=swap&subset=latin-ext" rel="stylesheet">
+    <link rel="stylesheet" href="../css/style.css">
+    <link rel="stylesheet" href="../css/custom.css">
+    <link rel="stylesheet" href="../css/changes.css">
+    <link rel="stylesheet" href="../css/fonts.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.2/animation_utility.css">
+    <link rel="icon" type="image/x-icon" href="../image/red_LOGO_Vandore.png?v=2025">
+    <title data-i18n="vandore_heritage_services" data-sb-field-path="title">Vandore Heritage - pakalpojumi</title>
+</head>
+
+<body>
+    <!-- Header -->
+    <header class="bg-accent-primary px-5">
+        <nav class="navbar">
+            <div class="container-fluid ps-3 gap-3">
+                <div class="me-auto"></div>
+                <div class="logo-container position-absolute start-50 translate-middle-x" style="margin-top: 2cm;">
+                    <a class="navbar-brand" href="index.html"><img src="../image/red_LOGO_Vandore.png?v=2025" alt="Vandore Heritage" class="img-fluid"></a>
+                </div>
+                <div class="w-max-content" style="margin-top: 0.5cm;">
+                    <button class="btn btn-toggler-accent" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDark" aria-controls="offcanvasDark"><i class="fa-solid fa-bars"></i>
+                        Menu</button>
+
+                    <div class="offcanvas offcanvas-end offcanvas-fullwidth text-bg-dark" tabindex="-1" id="offcanvasDark" aria-labelledby="offcanvasRightLabel">
+                        <div class="offcanvas-header bg-transparent">
+                            <h5 id="offcanvasRightLabel">Menu</h5>
+                            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+                        </div>
+                        <div class="offcanvas-body">
+                            <div class="r-container">
+                                <div class="row row-cols-xl-2 row-cols-1">
+                                    <div class="col col-xl-10 mb-3">
+                                        <div class="d-flex flex-column">
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="01_homepage">01. Mājas lapa</span>
+                                                <img src="../image/img6.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="index.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="02_properties">02. Īpašumi</span>
+                                                <img src="../image/img5.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="properties.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="03_short_form_rentals">03. Īsas formas īre</span>
+                                                <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="rentals.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="04_about_us">04. Par mums</span>
+                                                <img src="../image/img33.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="about.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="05_services">05. Pakalpojumi</span>
+                                                <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="service.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="06_contact">06. Sazinieties</span>
+                                                <img src="../image/img29.png" class="img-fluid rounded-3 " style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="contact.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="07_news">07. Jaunumi</span>
+                                                <img src="../image/img26.png" class="img-fluid rounded-3 " style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="blog.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col col-xl-2 mb-3">
+                                        <div class="d-flex flex-column gap-5 accent-primary text-end">
+                                           <div class="d-flex flex-column gap-4">
+                                                <h6 data-i18n="riga_latvia">Rīga, Latvija</h6>
+                                                <div class="d-flex flex-column gap-3">
+                                                    <span data-i18n="skanstes_iela_29a91_rga_latvia">
+                                                        Skanstes Iela 29A - 91, Rīga, Latvija
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </nav>
+    </header>
+    <!-- End Header -->
+
+    <!-- Main -->
+    <main>
+        <!-- Banner -->
+        <div class="section position-relative bg-attach-cover">
+            <div class="r-container position-relative h-100">
+                <div class="position-absolute top-0 start-0 end-0 bottom-0 h-100 w-100" style="margin-top: 10rem;">
+                    <div class="row row-cols-2">
+                        <div class="col-3 col-xl-2"></div>
+                        <div class="col-9 col-xl-10">
+                            <img src="../image/dummy-img-1920x900.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Vandore Heritage">
+                        </div>
+                    </div>
+                </div>
+                <div class="d-flex flex-column gap-5 justify-content-between scrollanimation animated fadeInLeft adr-7 h-100 padding-custom">
+                    <div class="d-flex flex-column gap-2 h-100">
+                        <div><h1 class="display" style="max-width: 700px;" data-i18n="our_services" data-sb-field-path="heroHeading">Mūsu pakalpojumi</h1>
+                        <div class="row row-xl-cols-2 row-cols-1">
+                            <div class="col col-xl-2">
+                                <div class="d-flex flex-column gap-2 align-items-xl-center align-items-start">
+                                    <p data-i18n="sales_acquisitions_renovation_design_rentals_and_legal_support_for_each_client" data-sb-field-path="heroSubheading">Pārdošana, iegāde, renovācija, dizains, īre un juridiskais atbalsts katram klientam.
+                                    </p></div>
+                                    <div class="devider"></div>
+                                </div>
+                            </div>
+                            <div class="col col-xl-10"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Section Our Service -->
+        <div class="section">
+            <div class="r-container d-flex flex-column gap-5">
+                <div class="row row-cols-xl-2 row-cols-1 align-items-end">
+                    <div class="col mb-3 scrollanimation animated fadeInLeft adr-7">
+                        <h3 data-i18n="services_tailored_to_every_project">Pakalpojumi, kas pielāgoti katram projektam.</h3>
+                    </div>
+                    <div class="col mb-3 scrollanimation animated fadeInDown adr-7">
+                        <div class="d-flex flex-column gap-2 align-items-end">
+                            <p style="max-width: 400px;">
+                                
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="row row-cols-xl-3 row-cols-1">
+                    <div class="col mb-3">
+                        <div class="card card-service" id="property-sales-acquisitions">
+                            <div class="d-flex flex-row gap-3 align-items-center">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="CurrentColor" width="66" height="66" data-name="Layer 3" viewBox="0 0 500 500">
+                                    <path d="M59.44,175.81c-9.2,44,3.06,91.63,37.15,125.72,36.95,36.96,90.47,49.44,140.29,33.09l13.71-.69,8.62,7.78,2.56,33.67c.38,4.99,2.67,9.64,6.36,13l22.19,20.18c3.97,3.61,9.26,5.55,14.59,5.05l31.56-2.28,9.22,8.11,1.61,32.64c.26,5.19,2.56,10.06,6.41,13.56l21.32,19.31c3.67,3.32,8.38,5.06,13.15,5.06,2.42,0,4.86-.45,7.18-1.36l59.93-23.62c5.73-2.26,10.05-7.07,11.69-12.98l17.28-62.24c1.99-7.15-.24-14.82-5.76-19.79l-150.65-135.72c10.47-46.08-2.96-93.95-36.51-127.49-37.34-37.34-90.8-48.08-138.05-33.5-12.65-22.13-29.52-40.46-47.84-51.59-21.95-13.33-44.65-15.38-62.29-5.6C9.43,34.79,5.49,90.02,34.17,141.85c7.29,13.16,15.95,24.44,25.27,33.96ZM263.64,134.49c26.12,26.12,35.12,64.52,23.5,100.19-2.4,7.36-.24,15.44,5.51,20.62l150.63,135.69-11.43,41.15-39.53,15.57-6.29-5.69-1.62-32.8c-.26-5.28-2.65-10.24-6.62-13.74l-21.6-19.02c-3.95-3.47-9.23-5.28-14.36-4.83l-31.37,2.27-10.22-9.28-2.56-33.72c-.38-5.01-2.69-9.69-6.43-13.06l-20.46-18.43c-3.85-3.47-8.63-5.14-14.08-5.01l-24.52,1.21c-1.89.09-3.75.46-5.53,1.08-36.26,12.79-75.49,3.99-102.37-22.88-19.92-19.92-29.28-46.32-28.54-72.48,8.7,3.6,17.41,5.67,25.77,5.67,8.48-.01,16.6-1.95,24-6.05,9.46-5.24,12.89-17.17,7.65-26.63-5.23-9.46-17.17-12.87-26.63-7.65-4.6,2.55-12.53,1.07-21.54-4.04,4.72-10.15,10.92-19.79,19.29-28.16,38.4-38.4,100.93-38.43,139.35,0ZM62.14,50.38c4.95-2.7,13.53-.93,22.97,4.81,11.76,7.14,23.27,19.67,32.33,34.57-7.35,4.92-14.37,10.54-20.86,17.03-8.43,8.43-15.06,17.9-20.85,27.73-2.51-3.6-4.96-7.45-7.28-11.65-19.65-35.5-16.86-66.65-6.31-72.49Z" stroke-width="0"></path>
+                                </svg>
+                                <h4 data-i18n="property_sales_acquisitions">Īpašuma pārdošana un iegāde</h4>
+                            </div>
+                            <p>Valuation, photos &amp; content, marketing, negotiation, and closing.<br>Search, due diligence, and purchase support.</p>
+                            <p data-i18n="included_support_legal_support_transaction_guidance_and_documentation">Iekļauts atbalsts: juridiskais atbalsts - darījumu norādījumi un dokumentācija.</p>
+                        </div>
+                    </div>
+                    <div class="col mb-3">
+                        <div class="card card-service" id="renovation-project-coordination">
+                            <div class="d-flex flex-row gap-3 align-items-center">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="CurrentColor" width="66" data-name="Layer 3" viewBox="0 0 500 500">
+                                    <path d="M61.13,356.03v90.89c0,23.75,19.33,43.08,43.08,43.08h291.59c23.75,0,43.08-19.33,43.08-43.08v-90.89c0-66.13-45.66-121.66-107.06-137.11,23.77-22.06,38.9-53.3,38.9-88.21,0-.24-.07-.45-.07-.69,0-.11.05-.2.05-.31,0-.17-.11-.31-.13-.49-.54-43.6-24.43-81.33-59.6-102.11-1.83-1.54-3.93-2.69-6.33-3.44-16.48-8.45-34.87-13.68-54.63-13.68-66.56,0-120.71,54.15-120.71,120.71,0,9.6,1.41,18.82,3.54,27.78.03.08.04.16.08.24,5.64,23.52,18.11,44.25,35.29,60.19-61.4,15.46-107.06,70.98-107.06,137.11ZM240.52,268.46h18.97l19.71,98.55-29.21,29.19-29.18-29.19,19.71-98.55ZM331.49,111.95c-22.21-1.99-32.08-9.75-36.12-15.04,5.17-7.77,9.68-16.36,13.51-25.7,11.08,10.97,18.99,25.04,22.61,40.74ZM271.01,124.95c10.75,11.04,29.26,21.91,60.63,24.04-8.38,37.41-41.73,65.5-81.64,65.5-32.75,0-60.88-19.07-74.65-46.53,29.68-4.4,66.35-16.89,95.66-43.02ZM250,46.92c9.47,0,18.42,1.92,26.91,4.83-21.44,61.18-81.34,76.33-110.59,80.05,0-.37-.11-.72-.11-1.09,0-46.2,37.58-83.79,83.79-83.79ZM202.67,251.42h3.61l-23.61,118.04c-1.21,6.05.69,12.31,5.05,16.67l49.22,49.23c3.46,3.46,8.15,5.41,13.05,5.41s9.59-1.95,13.05-5.41l49.24-49.23c4.36-4.36,6.26-10.63,5.05-16.67l-23.61-118.04h3.61c57.68,0,104.62,46.94,104.62,104.62v90.89c0,3.39-2.76,6.15-6.15,6.15H104.21c-3.39,0-6.15-2.76-6.15-6.15v-90.89c0-57.68,46.94-104.62,104.62-104.62Z" stroke-width="0"></path>
+                                </svg>
+                                <h4 data-i18n="renovation_project_coordination">Renovācija un projekta koordinācija</h4>
+                            </div>
+                            <p>Scope, contractors, schedule, and quality control.<br>From minor improvements to complete renovations, we coordinate the process from start to handover.</p>
+                            <p data-i18n="included_support_interior_design_custom_furniture_concepts_sourcing_and_styling_for_your_new_space">Iekļauts atbalsts: interjera dizains un pielāgotas mēbeles - jēdzieni, iegūšana un jūsu jaunās telpas stils.</p>
+                        </div>
+                    </div>
+                    <div class="col mb-3">
+                        <div class="card card-service" id="short-term-rental-preparation-management">
+                            <div class="d-flex flex-row gap-3 align-items-center">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="CurrentColor" width="66" height="66" data-name="Layer 3" viewBox="0 0 500 500">
+                                    <path d="M451.94,231.45l-143.79-143.79c1.56-5.38,2.67-10.96,2.67-16.84,0-33.53-27.28-60.81-60.81-60.81s-60.81,27.28-60.81,60.81c0,5.95,1.13,11.59,2.73,17.03L48.07,231.44c-21.66,4.2-38.07,23.26-38.07,46.12v165.41c0,25.93,21.09,47.03,47.03,47.03h385.95c25.93,0,47.03-21.09,47.03-47.03v-165.41c0-22.86-16.41-41.92-38.06-46.12ZM250,48.92c12.07,0,21.89,9.82,21.89,21.89s-9.82,21.89-21.89,21.89-21.89-9.82-21.89-21.89,9.82-21.89,21.89-21.89ZM214.67,120.11c9.98,7.17,22.12,11.51,35.33,11.51s25.45-4.39,35.46-11.62l110.54,110.54H104.06l110.62-110.43ZM451.08,442.97c0,4.47-3.64,8.11-8.11,8.11H57.03c-4.47,0-8.11-3.64-8.11-8.11v-165.41c0-4.47,3.64-8.11,8.11-8.11h385.95c4.47,0,8.11,3.64,8.11,8.11v165.41Z" stroke-width="0"></path>
+                                    <path d="M148.8,381.64c-2.5-4.09-5.36-7.99-8.53-11.59-1.23-1.39-2.48-2.66-3.76-3.81,4.9-1.91,8.88-4.45,11.88-7.6,4.59-4.88,6.9-11.35,6.9-19.27,0-3.84-.67-7.54-2-10.98-1.36-3.51-3.36-6.63-5.97-9.3-2.61-2.64-5.62-4.7-8.87-6.06-2.74-1.25-5.84-2.1-9.27-2.52-3.19-.38-6.89-.56-11.3-.56h-30.58c-5.09,0-8.98,1.29-11.58,3.88-2.55,2.56-3.84,6.45-3.84,11.54v71.45c0,4.7,1.14,8.42,3.38,11.07,4.64,5.45,14.39,5.79,19.59.25,2.39-2.6,3.61-6.41,3.61-11.33v-25.95h2.7c2.83,0,5.13.35,6.84,1.05,1.63.66,3.33,1.98,5.04,3.9,1.99,2.26,4.28,5.59,6.83,9.95l7.55,12.54c1.82,3.04,3.26,5.35,4.32,6.9,1.29,1.89,2.86,3.48,4.73,4.8,2.09,1.43,4.62,2.15,7.51,2.15,2.43,0,4.62-.51,6.42-1.46,1.95-.98,3.55-2.38,4.79-4.26,1.17-1.86,1.75-3.79,1.75-5.71,0-1.22-.27-3.22-2.31-7.98-1.36-3.26-3.26-6.89-5.84-11.12ZM126.95,345.79c-1.08,1.25-2.79,2.18-5.07,2.76-2.76.7-6.27,1.05-10.45,1.05h-12.96v-17.75h13.47c8.03,0,10.71.76,11.48,1.09,1.62.68,2.85,1.66,3.71,2.94.89,1.36,1.32,2.89,1.32,4.69,0,2.32-.51,4.07-1.49,5.22Z" stroke-width="0"></path>
+                                    <path d="M231.86,387.86h-39.95v-18.64h35.13c3.91,0,6.99-1.03,9.16-3.08,2.17-2.09,3.27-4.76,3.27-7.97s-1.18-5.97-3.37-7.94c-2.13-1.98-5.18-2.98-9.06-2.98h-35.13v-15.03h38.48c3.95,0,7.08-1,9.34-3.03,2.24-2.08,3.42-4.9,3.42-8.15s-1.19-6.04-3.45-8.1c-2.22-2.03-5.27-3.02-9.31-3.02h-49.66c-3.23,0-5.89.49-8.2,1.52-2.55,1.18-4.51,3.14-5.62,5.61-1.06,2.22-1.6,5-1.6,8.29v69.81c0,5.08,1.28,8.96,3.81,11.54,2.55,2.57,6.46,3.88,11.6,3.88h51.13c3.94,0,7.07-1.03,9.29-3.07,2.31-2.09,3.52-4.94,3.52-8.23s-1.22-6.27-3.52-8.36c-2.22-2.04-5.35-3.07-9.29-3.07Z" stroke-width="0"></path>
+                                    <path d="M315.75,312.43c-2.14,2.52-3.23,6.08-3.23,10.59v42.29l-29.01-43.91-2.93-4.57c-1.08-1.68-2.18-3.13-3.27-4.23-1.24-1.29-2.72-2.32-4.36-3.05-3.95-1.8-9.76-1.57-14.05,1.24-2.51,1.6-4.36,3.75-5.55,6.55-.85,2.22-1.27,5.09-1.27,8.54v71.64c0,4.43,1.13,7.98,3.38,10.6,4.67,5.26,13.75,5.36,18.53.06,2.31-2.53,3.47-6.12,3.47-10.67v-41.33l28.19,43.2c1.04,1.52,2.07,2.99,3.09,4.41,1.22,1.7,2.5,3.13,3.85,4.33,1.53,1.38,3.26,2.43,5.09,3.09,1.76.63,3.74.95,5.88.95,4.22,0,14.02-1.57,14.02-16.11v-73.04c0-4.55-1.11-8.13-3.29-10.6-4.54-5.27-13.95-5.38-18.56.01Z" stroke-width="0"></path>
+                                    <path d="M424.46,313.12c-2.31-2.1-5.62-3.17-9.87-3.17h-59.8c-4,0-7.22,1.01-9.6,3.03-2.48,2.13-3.79,5.12-3.79,8.65s1.25,6.35,3.62,8.49c2.28,2.08,5.57,3.13,9.77,3.13h16.63v63.57c0,4.83,1.23,8.6,3.66,11.25,2.47,2.69,5.82,4.1,9.68,4.1s7.07-1.37,9.58-4.08c2.39-2.61,3.61-6.4,3.61-11.28v-63.57h16.63c4.17,0,7.47-1.04,9.78-3.08,2.45-2.14,3.74-5.09,3.74-8.54s-1.27-6.37-3.65-8.51Z" stroke-w_id_th="0"></path>
+                                </svg>
+                                <h4 data-i18n="shortterm_rental_preparation_management">Īstermiņa nomas sagatavošana un pārvaldība</h4>
+                            </div>
+                            <p>Setup, content and listings, guest communication, cleaning, maintenance, and pricing strategy.<br>Full management from preparation to ongoing operations.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        
+
+        <!-- Section Testimonial -->
+        <div class="section">
+            <div class="r-container d-flex flex-column gap-5">
+                <div class="d-flex flex-column gap-2 align-items-center justify-content-center mx-auto text-center  scrollanimation animated zoomIn adr-7" style="max-width: 850px;">
+                    <h3 data-i18n="why_they_love_us">Kāpēc viņi mūs mīl</h3>
+                    <p data-i18n="discover_the_voices_of_our_satisfied_clients_who_have_experienced_firsthand_the_exceptional_service_and_expertise_we_provide_in_helping_them_find_their_dream_homes">Atklājiet mūsu apmierināto klientu balsis, kuri ir pieredzējuši ārkārtas situāciju 
+Pakalpojumi un kompetence, ko mēs sniedzam, palīdzot viņiem atrast savas sapņu mājas.</p>
+                </div>
+                <div class="overflow-hidden">
+                    <div class="swiper swiperTestimonials">
+                        <!-- Additional required wrapper -->
+                        <div class="swiper-wrapper pt-5">
+                            <!-- Slides -->
+                            <div class="swiper-slide">
+                                <div class="card testimonial-container">
+                                    <div class="position-absolute start-0 top-0 overflow-visible" style="z-index: 9999; margin-left: 4rem; margin-top: -2rem;">
+                                        <div class="customer-item">
+                                            <img src="../image/dummy-img-400x400.jpg" class="img-fluid" alt="Vandore Heritage">
+                                        </div>
+                                    </div>
+                                    <div class="d-flex flex-column gap-3">
+                                        <p data-i18n="vandore_heritage_client_review_will_appear_here_after_approval">Pēc apstiprināšanas šeit parādīsies Vandore Heritage Client Review.</p>
+                                        <div class="d-flex flex-row gap-3 align-items-center justify-content-between">
+                                            <div class="d-flex flex-column gap-2">
+                                                <h5 class="m-0 team-name"></h5>
+                                                <div class="flex-row">
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                </div>
+                                            </div>
+                                            <i class="rtmicon rtmicon-blockquote gray-hover" style="font-size: 82px;"></i>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="swiper-slide">
+                                <div class="card testimonial-container">
+                                    <div class="position-absolute start-0 top-0 overflow-visible" style="z-index: 9999; margin-left: 4rem; margin-top: -2rem;">
+                                        <div class="customer-item">
+                                            <img src="../image/dummy-img-400x400.jpg" class="img-fluid" alt="Vandore Heritage">
+                                        </div>
+                                    </div>
+                                    <div class="d-flex flex-column gap-3">
+                                        <p data-i18n="vandore_heritage_client_review_will_appear_here_after_approval">Pēc apstiprināšanas šeit parādīsies Vandore Heritage Client Review.</p>
+                                        <div class="d-flex flex-row gap-3 align-items-center justify-content-between">
+                                            <div class="d-flex flex-column gap-2">
+                                                <h5 class="m-0 team-name"></h5>
+                                                <div class="flex-row">
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                </div>
+                                            </div>
+                                            <i class="rtmicon rtmicon-blockquote gray-hover" style="font-size: 82px;"></i>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="swiper-slide">
+                                <div class="card testimonial-container">
+                                    <div class="position-absolute start-0 top-0 overflow-visible" style="z-index: 9999; margin-left: 4rem; margin-top: -2rem;">
+                                        <div class="customer-item">
+                                            <img src="../image/dummy-img-400x400.jpg" class="img-fluid" alt="Vandore Heritage">
+                                        </div>
+                                    </div>
+                                    <div class="d-flex flex-column gap-3">
+                                        <p data-i18n="vandore_heritage_client_review_will_appear_here_after_approval">Pēc apstiprināšanas šeit parādīsies Vandore Heritage Client Review.</p>
+                                        <div class="d-flex flex-row gap-3 align-items-center justify-content-between">
+                                            <div class="d-flex flex-column gap-2">
+                                                <h5 class="m-0 team-name"></h5>
+                                                <div class="flex-row">
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                </div>
+                                            </div>
+                                            <i class="rtmicon rtmicon-blockquote gray-hover" style="font-size: 82px;"></i>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="swiper-slide">
+                                <div class="card testimonial-container">
+                                    <div class="position-absolute start-0 top-0 overflow-visible" style="z-index: 9999; margin-left: 4rem; margin-top: -2rem;">
+                                        <div class="customer-item">
+                                            <img src="../image/dummy-img-400x400.jpg" class="img-fluid" alt="Vandore Heritage">
+                                        </div>
+                                    </div>
+                                    <div class="d-flex flex-column gap-3">
+                                        <p data-i18n="vandore_heritage_client_review_will_appear_here_after_approval">Pēc apstiprināšanas šeit parādīsies Vandore Heritage Client Review.</p>
+                                        <div class="d-flex flex-row gap-3 align-items-center justify-content-between">
+                                            <div class="d-flex flex-column gap-2">
+                                                <h5 class="m-0 team-name"></h5>
+                                                <div class="flex-row">
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                </div>
+                                            </div>
+                                            <i class="rtmicon rtmicon-blockquote gray-hover" style="font-size: 82px;"></i>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="swiper-slide">
+                                <div class="card testimonial-container">
+                                    <div class="position-absolute start-0 top-0 overflow-visible" style="z-index: 9999; margin-left: 4rem; margin-top: -2rem;">
+                                        <div class="customer-item">
+                                            <img src="../image/dummy-img-400x400.jpg" class="img-fluid" alt="Vandore Heritage">
+                                        </div>
+                                    </div>
+                                    <div class="d-flex flex-column gap-3">
+                                        <p data-i18n="vandore_heritage_client_review_will_appear_here_after_approval">Pēc apstiprināšanas šeit parādīsies Vandore Heritage Client Review.</p>
+                                        <div class="d-flex flex-row gap-3 align-items-center justify-content-between">
+                                            <div class="d-flex flex-column gap-2">
+                                                <h5 class="m-0 team-name"></h5>
+                                                <div class="flex-row">
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                </div>
+                                            </div>
+                                            <i class="rtmicon rtmicon-blockquote gray-hover" style="font-size: 82px;"></i>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="swiper swiperTestimonials2 pt-5">
+                        <!-- Additional required wrapper -->
+                        <div class="swiper-wrapper">
+                            <!-- Slides -->
+                            <div class="swiper-slide">
+                                <div class="card testimonial-container">
+                                    <div class="position-absolute start-0 top-0 overflow-visible" style="z-index: 9999; margin-left: 4rem; margin-top: -2rem;">
+                                        <div class="customer-item">
+                                            <img src="../image/dummy-img-400x400.jpg" class="img-fluid" alt="Vandore Heritage">
+                                        </div>
+                                    </div>
+                                    <div class="d-flex flex-column gap-3">
+                                        <p data-i18n="vandore_heritage_client_review_will_appear_here_after_approval">Pēc apstiprināšanas šeit parādīsies Vandore Heritage Client Review.</p>
+                                        <div class="d-flex flex-row gap-3 align-items-center justify-content-between">
+                                            <div class="d-flex flex-column gap-2">
+                                                <h5 class="m-0 team-name"></h5>
+                                                <div class="flex-row">
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                </div>
+                                            </div>
+                                            <i class="rtmicon rtmicon-blockquote gray-hover" style="font-size: 82px;"></i>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="swiper-slide">
+                                <div class="card testimonial-container">
+                                    <div class="position-absolute start-0 top-0 overflow-visible" style="z-index: 9999; margin-left: 4rem; margin-top: -2rem;">
+                                        <div class="customer-item">
+                                            <img src="../image/dummy-img-400x400.jpg" class="img-fluid" alt="Vandore Heritage">
+                                        </div>
+                                    </div>
+                                    <div class="d-flex flex-column gap-3">
+                                        <p data-i18n="vandore_heritage_client_review_will_appear_here_after_approval">Pēc apstiprināšanas šeit parādīsies Vandore Heritage Client Review.</p>
+                                        <div class="d-flex flex-row gap-3 align-items-center justify-content-between">
+                                            <div class="d-flex flex-column gap-2">
+                                                <h5 class="m-0 team-name"></h5>
+                                                <div class="flex-row">
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                </div>
+                                            </div>
+                                            <i class="rtmicon rtmicon-blockquote gray-hover" style="font-size: 82px;"></i>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="swiper-slide">
+                                <div class="card testimonial-container">
+                                    <div class="position-absolute start-0 top-0 overflow-visible" style="z-index: 9999; margin-left: 4rem; margin-top: -2rem;">
+                                        <div class="customer-item">
+                                            <img src="../image/dummy-img-400x400.jpg" class="img-fluid" alt="Vandore Heritage">
+                                        </div>
+                                    </div>
+                                    <div class="d-flex flex-column gap-3">
+                                        <p data-i18n="vandore_heritage_client_review_will_appear_here_after_approval">Pēc apstiprināšanas šeit parādīsies Vandore Heritage Client Review.</p>
+                                        <div class="d-flex flex-row gap-3 align-items-center justify-content-between">
+                                            <div class="d-flex flex-column gap-2">
+                                                <h5 class="m-0 team-name"></h5>
+                                                <div class="flex-row">
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                </div>
+                                            </div>
+                                            <i class="rtmicon rtmicon-blockquote gray-hover" style="font-size: 82px;"></i>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="swiper-slide">
+                                <div class="card testimonial-container">
+                                    <div class="position-absolute start-0 top-0 overflow-visible" style="z-index: 9999; margin-left: 4rem; margin-top: -2rem;">
+                                        <div class="customer-item">
+                                            <img src="../image/dummy-img-400x400.jpg" class="img-fluid" alt="Vandore Heritage">
+                                        </div>
+                                    </div>
+                                    <div class="d-flex flex-column gap-3">
+                                        <p data-i18n="vandore_heritage_client_review_will_appear_here_after_approval">Pēc apstiprināšanas šeit parādīsies Vandore Heritage Client Review.</p>
+                                        <div class="d-flex flex-row gap-3 align-items-center justify-content-between">
+                                            <div class="d-flex flex-column gap-2">
+                                                <h5 class="m-0 team-name"></h5>
+                                                <div class="flex-row">
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                </div>
+                                            </div>
+                                            <i class="rtmicon rtmicon-blockquote gray-hover" style="font-size: 82px;"></i>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="swiper-slide">
+                                <div class="card testimonial-container">
+                                    <div class="position-absolute start-0 top-0 overflow-visible" style="z-index: 9999; margin-left: 4rem; margin-top: -2rem;">
+                                        <div class="customer-item">
+                                            <img src="../image/dummy-img-400x400.jpg" class="img-fluid" alt="Vandore Heritage">
+                                        </div>
+                                    </div>
+                                    <div class="d-flex flex-column gap-3">
+                                        <p data-i18n="vandore_heritage_client_review_will_appear_here_after_approval">Pēc apstiprināšanas šeit parādīsies Vandore Heritage Client Review.</p>
+                                        <div class="d-flex flex-row gap-3 align-items-center justify-content-between">
+                                            <div class="d-flex flex-column gap-2">
+                                                <h5 class="m-0 team-name"></h5>
+                                                <div class="flex-row">
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                                </div>
+                                            </div>
+                                            <i class="rtmicon rtmicon-blockquote gray-hover" style="font-size: 82px;"></i>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- If we need pagination -->
+                    <div class="swiper-pagination"></div>
+                </div>
+            </div>
+        </div>
+
+    </main>
+
+    <footer>
+        <div class="section position-relative bg-black-1" style="height: 90vh;">
+            <div class="row row-cols-xl-2 row-cols-1 h-100">
+                <div class="col col-xl-8 mb-3">
+                    <div class="d-flex flex-column gap-3 justify-content-between h-100">
+                        <div class="d-flex flex-column accent-primary">
+                            <p class="gray" data-i18n="get_contact">Sazināties</p>
+                            <h1 class="fw-normal" data-i18n="infovandoreheritagelv">info@vandoreheritage.lv</h1>
+                        </div>
+                        <img src="../image/logo-footer.png?v=2025" alt="Vandore Heritage" class="img-fluid" width="938">
+                    </div>
+                </div>
+                <div class="col col-xl-4 mb-3">
+                    <div class="d-flex flex-column gap-5 justify-content-between accent-primary h-100">
+                        <div class="d-flex flex-row gap-5">
+                            <ul class="list-unstyled d-flex flex-column gap-3 accent-color">
+                                <li>
+                                    <a href="index.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="home">
+                                        Mājas
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="about.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="about">
+                                        Pret
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="properties.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="properties">
+                                        Īpašības
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="rentals.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="rentals">
+                                        Īre
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="service.html" class="link active d-flex flex-row gap-3 align-items-center" data-i18n="service">
+                                        Sakārtošana
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="contact.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="contact_us">
+                                        Sazinieties ar mums
+                                    </a>
+                                </li>
+                            </ul>
+                            <div class="d-flex flex-column gap-3">
+                                <a href="https://www.google.com/maps/place/Skanstes+iela+29A,+Vidzemes+priekšpilsēta,+Rīga,+LV-1013,+Latvia" class="link" target="_blank" data-i18n="skanstes_iela_29a91_rga_latvia">
+                                    Skanstes Iela 29A - 91, Rīga, Latvija
+                                </a>
+                                <a href="tel:+37129713030" class="link" data-i18n="371_29_71_3030">
+                                    +371 29 71 3030
+                                </a>
+                            </div>
+                        </div>
+                        <div class="d-flex flex-row gap-3">
+                            <div class="border-end pe-3 border-gray">
+                                <a href="" class="link d-flex flex-row gap-3 align-items-center" data-i18n="terms_conditions">
+                                    Noteikumi un nosacījumi
+                                </a>
+                            </div>
+                            <div>
+                                <a href="" class="link d-flex flex-row gap-3 align-items-center" data-i18n="privacy_notice">
+                                    Paziņojums par privātumu
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+
+    <!-- Back to top button -->
+    <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="rtmicon rtmicon-arrow-up"></i></a>
+
+    <!-- Scripts -->
+    <script src="../js/vendor/jquery.min.js"></script>
+    <script src="../js/vendor/bootstrap.bundle.min.js"></script>
+    <script src="../js/vendor/swiper-bundle.min.js"></script>
+    <script src="../js/script.js"></script>
+    <script src="../js/swiper-script.js"></script>
+    <script src="../js/submit-form.js"></script>
+    <script src="../js/vendor/isotope.pkgd.min.js"></script>
+    <script src="../js/video_embedded.js"></script>
+    <script src="../js/vendor/fslightbox.js"></script>
+    <script src="../js/custom.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.0/oyethemes_onscroll_animation.js"></script>
+
+
+</body></html>

--- a/_site/single_blog.html
+++ b/_site/single_blog.html
@@ -1,0 +1,462 @@
+<!DOCTYPE html><html lang="lv" data-sb-object-id="content/pages/single_blog.json"><head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;600&family=Noto+Serif:wght@700&display=swap&subset=latin-ext" rel="stylesheet">
+    <link rel="stylesheet" href="../css/style.css">
+    <link rel="stylesheet" href="../css/custom.css">
+    <link rel="stylesheet" href="../css/fonts.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.2/animation_utility.css">
+    <link rel="icon" type="image/x-icon" href="../image/red_LOGO_Vandore.png?v=2025">
+    <title data-i18n="vandore_heritage_single_post" data-sb-field-path="title">Vandore Heritage - viena ziņa</title>
+</head>
+
+<body>
+    <!-- Header -->
+    <header class="bg-accent-primary px-5">
+        <nav class="navbar">
+            <div class="container-fluid ps-3 gap-3">
+                <div class="me-auto"></div>
+                <div class="logo-container position-absolute start-50 translate-middle-x" style="margin-top: 2cm;">
+                    <a class="navbar-brand" href="index.html"><img src="../image/red_LOGO_Vandore.png?v=2025" alt="Vandore Heritage" class="img-fluid"></a>
+                </div>
+                <div class="w-max-content" style="margin-top: 0.5cm;">
+                    <button class="btn btn-toggler-accent" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDark" aria-controls="offcanvasDark"><i class="fa-solid fa-bars"></i>
+                        Menu</button>
+
+                    <div class="offcanvas offcanvas-end offcanvas-fullwidth text-bg-dark" tabindex="-1" id="offcanvasDark" aria-labelledby="offcanvasRightLabel">
+                        <div class="offcanvas-header bg-transparent">
+                            <h5 id="offcanvasRightLabel">Menu</h5>
+                            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+                        </div>
+                        <div class="offcanvas-body">
+                            <div class="r-container">
+                                <div class="row row-cols-xl-2 row-cols-1">
+                                    <div class="col col-xl-10 mb-3">
+                                        <div class="d-flex flex-column">
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="01_homepage">01. Mājas lapa</span>
+                                                <img src="../image/img6.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="index.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="02_properties">02. Īpašumi</span>
+                                                <img src="../image/img5.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="properties.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="03_short_form_rentals">03. Īsas formas īre</span>
+                                                <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="rentals.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="04_about_us">04. Par mums</span>
+                                                <img src="../image/img33.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="about.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="05_services">05. Pakalpojumi</span>
+                                                <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="service.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="06_contact">06. Sazinieties</span>
+                                                <img src="../image/img29.png" class="img-fluid rounded-3 " style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="contact.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="07_news">07. Jaunumi</span>
+                                                <img src="../image/img26.png" class="img-fluid rounded-3 " style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="blog.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col col-xl-2 mb-3">
+                                        <div class="d-flex flex-column gap-5 accent-primary text-end">
+                                           <div class="d-flex flex-column gap-4">
+                                                <h6 data-i18n="riga_latvia">Rīga, Latvija</h6>
+                                                <div class="d-flex flex-column gap-3">
+                                                    <span data-i18n="skanstes_iela_29a91_rga_latvia">
+                                                        Skanstes Iela 29A - 91, Rīga, Latvija
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </nav>
+    </header>
+    <!-- End Header -->
+
+    <!-- Main -->
+    <main>
+        <!-- Banner -->
+        <div class="section position-relative bg-attach-cover">
+            <div class="r-container position-relative h-100">
+                <div class="position-absolute top-0 start-0 end-0 bottom-0 h-100 w-100" style="margin-top: 10rem;">
+                    <div class="row row-cols-2">
+                        <div class="col-3 col-xl-2"></div>
+                        <div class="col-9 col-xl-10">
+                            <img src="../image/dummy-img-1920x900.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Vandore Heritage">
+                        </div>
+                    </div>
+                </div>
+                <div class="d-flex flex-column gap-5 justify-content-between scrollanimation animated fadeInLeft adr-7 h-100 padding-custom">
+                    <div class="d-flex flex-column gap-2 h-100">
+                        <div><h1 class="display" data-i18n="expert_market_insights" data-sb-field-path="heroHeading">Ekspertu tirgus ieskats</h1>
+                        <div class="row row-xl-cols-2 row-cols-1">
+                            <div class="col col-xl-2">
+                                <div class="d-flex flex-column gap-2 align-items-xl-center align-items-start">
+                                    <p data-i18n="gain_valuable_knowledge_and_trends_from_real_estate_experts" data-sb-field-path="heroSubheading">Iegūstiet vērtīgas zināšanas un tendences no nekustamā īpašuma ekspertiem.
+                                    </p></div>
+                                    <div class="devider"></div>
+                                </div>
+                            </div>
+                            <div class="col col-xl-10"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Section Single Blog -->
+        <div class="section bg-attach-cover" style="background-image: url(../image/bg_post.png);">
+            <div class="r-container d-flex flex-column gap-4">
+                <div class="row row-cols-xl-2 row-cols-1">
+                    <div class="col col-xl-8 mb-3">
+                        <div class="d-flex flex-column gap-4 position-relative">
+                            <h3 data-i18n="discover_unparalleled_expertise_in_market">Atklājiet nepārspējamu kompetenci tirgū</h3>
+                            <img src="../image/dummy-img-900x600.jpg" alt="Vandore Heritage" class="img-fluid rounded-2" style="aspect-ratio: 3/2;">
+                            <div class="d-flex flex-column gap-3">
+                                <div class="d-flex flex-row gap-3">
+                                    <p data-i18n="jan_01_2025">2025. gada 1. janvāris</p>
+                                    <p data-i18n="2_min_read">2 min Lasīt</p>
+                                </div>
+                                <hr class="m-0">
+                                <p data-i18n="at_vandore_heritage_we_offer_unrivaled_expertise_in_the_real_estate_market_built_on_years_of_experience_and_a_deep_understanding_of_market_dynamics_our_team_of_professionals_is_committed_to_helping_you_make_informed_decisions_whether_youre_buying_selling_or_renting_properties_we_work_closely_with_clients_to_understand_their_specific_needs_and_goals_providing_tailored_strategies_that_ensure_a_smooth_stressfree_process_whether_youre_new_to_the_market_or_an_experienced_investor_our_knowledge_and_expertise_will_guide_you_every_step_of_the_way">
+                                    Vandore Heritage mēs piedāvājam nepārspējamu kompetenci nekustamā īpašuma tirgū, kas būvēts gados 
+pieredze un dziļa tirgus dinamikas izpratne. Mūsu profesionāļu komanda 
+ir apņēmies palīdzēt jums pieņemt apzinātus lēmumus neatkarīgi no tā, vai pērkat, pārdodat, 
+vai īrēt īpašumus. Mēs cieši sadarbojamies ar klientiem, lai saprastu viņu īpašo 
+vajadzības un mērķi, nodrošinot pielāgotas stratēģijas, kas nodrošina gludu, bez stresa 
+process Neatkarīgi no tā, vai esat jauns tirgū vai pieredzējis investors, mūsu zināšanas 
+Un kompetence palīdzēs jums ik uz soļa.
+                                </p>
+                                <p data-i18n="our_commitment_to_excellence_goes_beyond_just_facilitating_transactions_we_stay_uptodate_with_the_latest_market_trends_investment_opportunities_and_regulatory_changes_to_ensure_youre_always_ahead_of_the_curve_by_providing_you_with_accurate_timely_information_and_actionable_advice_we_empower_you_to_make_decisions_that_align_with_your_longterm_objectives_trust_in_vandore_heritage_to_provide_the_professional_support_and_market_insights_you_need_to_successfully_navigate_the_real_estate_landscape_ensuring_that_every_move_you_make_is_a_step_towards_securing_your_real_estate_goals">
+                                    Mūsu saistības ar izcilību pārsniedz tikai darījumu atvieglošanu. Mēs paliekam 
+aktuāls ar jaunākajām tirgus tendencēm, ieguldījumu iespējām un normatīvo aktu 
+Izmaiņas, lai nodrošinātu, ka jūs vienmēr esat priekšā līknei. Nodrošinot jums precīzu, 
+savlaicīga informācija un praktiski izmantojams padoms, mēs dodam iespēju pieņemt lēmumus 
+saskaņot ar saviem ilgtermiņa mērķiem. Uzticieties Vandore Heritage, lai nodrošinātu profesionāli 
+Atbalsts un tirgus ieskats, kas jums nepieciešams, lai veiksmīgi orientētos nekustamajā īpašumā 
+ainava, nodrošinot, ka katrs jūsu gājiens ir solis, lai nodrošinātu savu īsto 
+Īpašuma mērķi.
+                                </p>
+                                <div class="row row-cols-xl-2 row-cols-1">
+                                    <div class="col mb-3">
+                                        <img src="../image/dummy-img-600x400.jpg" class="img-fluid rounded-2" style="aspect-ratio: 5/3;" alt="Vandore Heritage">
+                                    </div>
+                                    <div class="col mb-3">
+                                        <div class="d-flex flex-column gap-3">
+                                            <h4 data-i18n="solutions">Risinājumi:</h4>
+                                            <div class="d-flex flex-row align-items-center font-2 gap-3">
+                                                <i class="rtmicon rtmicon-arrow-up-right fs-5"></i>
+                                                <span class="text-color-2" data-i18n="years_of_experience">Gadu pieredze</span>
+                                            </div>
+                                            <div class="d-flex flex-row align-items-center font-2 gap-3">
+                                                <i class="rtmicon rtmicon-arrow-up-right fs-5"></i>
+                                                <span class="text-color-2" data-i18n="personalized_guidance">Personalizētas vadības</span>
+                                            </div>
+                                            <div class="d-flex flex-row align-items-center font-2 gap-3">
+                                                <i class="rtmicon rtmicon-arrow-up-right fs-5"></i>
+                                                <span class="text-color-2" data-i18n="uptodate_market_insights">Aktuāls tirgus ieskats</span>
+                                            </div>
+                                            <div class="d-flex flex-row align-items-center font-2 gap-3">
+                                                <i class="rtmicon rtmicon-arrow-up-right fs-5"></i>
+                                                <span class="text-color-2" data-i18n="comprehensive_support">Visaptverošs atbalsts</span>
+                                            </div>
+                                            <div class="d-flex flex-row align-items-center font-2 gap-3">
+                                                <i class="rtmicon rtmicon-arrow-up-right fs-5"></i>
+                                                <span class="text-color-2" data-i18n="expert_investment_advice">Ekspertu investīciju padoms</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <p data-i18n="in_conclusion_vandore_heritages_unparalleled_expertise_in_the_real_estate_market_ensures_that_you_are_wellequipped_to_navigate_the_complexities_of_property_transactions_with_confidence_whether_you_are_buying_selling_or_investing_our_teams_deep_knowledge_personalized_approach_and_commitment_to_staying_ahead_of_market_trends_guarantee_that_your_goals_are_met_with_precision_and_efficiency_trust_us_to_provide_you_with_the_insights_and_support_you_need_and_experience_a_seamless_journey_towards_achieving_your_real_estate_objectives">
+                                    Noslēgumā jāsaka, ka Vandore Heritage nepārspējamā kompetence nekustamā īpašuma tirgū nodrošina 
+ka jūs esat labi sagatavots, lai pārvietotos īpašuma darījumu sarežģītībā 
+ar pārliecību. Neatkarīgi no tā, vai jūs pērkat, pārdodat vai ieguldāt mūsu komandas dziļi 
+zināšanas, personalizēta pieeja un apņemšanās palikt priekšā tirgus tendencēm 
+Garantējiet, ka jūsu mērķi tiek sasniegti ar precizitāti un efektivitāti. Uzticieties mums, lai nodrošinātu 
+jūs ar nepieciešamo ieskatu un atbalstu, kā arī piedzīvojat nemanāmu ceļojumu 
+Lai sasniegtu savus nekustamā īpašuma mērķus.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col col-xl-4 mb-3">
+                        <div class="d-flex flex-column gap-5">
+                            <div class="d-flex flex-column gap-4 ps-xl-3">
+                                <h4 class="m-0" data-i18n="recent_blog">Nesenais emuārs</h4>
+                                <hr class="m-0">
+                                <div class="row row-cols-xl-2 row-cols-1">
+                                    <div class="col col-xl-4 mb-3">
+                                        <img src="../image/dummy-img-600x400.jpg" alt="Vandore Heritage" class="img-fluid rounded-4 h-100" style="aspect-ratio: 5/3;">
+                                    </div>
+                                    <div class="col col-xl-8 mb-3">
+                                        <a href="single_blog.html">
+                                            <div class="d-flex flex-column">
+                                                <div class="d-flex flex-row gap-3">
+                                                    <p data-i18n="jan_04_2025">2025. gada 4. janvāris</p>
+                                                    <p data-i18n="2_min_read">2 min Lasīt</p>
+                                                </div>
+                                                <h6 class="black-1 font-1" data-i18n="tips_for_choosing_house_paint_colors_to_look">Padomi, kā izvēlēties mājas krāsas krāsas, lai izskatās ...</h6>
+                                            </div>
+                                        </a>
+                                    </div>
+                                </div>
+                                <div class="row row-cols-xl-2 row-cols-1">
+                                    <div class="col mb-3 col-xl-4">
+                                        <img src="../image/dummy-img-600x400.jpg" alt="Vandore Heritage" class="img-fluid rounded-4 h-100" style="aspect-ratio: 5/3;">
+                                    </div>
+                                    <div class="col mb-3 col-xl-8">
+                                        <a href="single_blog.html">
+                                            <div class="d-flex flex-column">
+                                                <div class="d-flex flex-row gap-3">
+                                                    <p data-i18n="jan_03_2025">2025. gada 3. janvāris</p>
+                                                    <p data-i18n="4_min_read">4 minūtes Lasīt</p>
+                                                </div>
+                                                <h6 class="black-1 font-1" data-i18n="modern_minimalist_home_design_inspirat">Mūsdienu minimālisma mājas dizains iedvesmo ...</h6>
+                                            </div>
+                                        </a>
+                                    </div>
+                                </div>
+                                <div class="row row-cols-xl-2 row-cols-1">
+                                    <div class="col mb-3 col-xl-4">
+                                        <img src="../image/dummy-img-600x400.jpg" alt="Vandore Heritage" class="img-fluid rounded-4 h-100" style="aspect-ratio: 5/3;">
+                                    </div>
+                                    <div class="col mb-3 col-xl-8">
+                                        <a href="single_blog.html">
+                                            <div class="d-flex flex-column">
+                                                <div class="d-flex flex-row gap-3">
+                                                    <p data-i18n="jan_02_2025">2025. gada 2. janvāris</p>
+                                                    <p data-i18n="3_min_read">3 minūtes Lasīt</p>
+                                                </div>
+                                                <h6 class="black-1 font-1" data-i18n="common_home_design_mistakes_to_av">Parastās mājas dizaina kļūdas AV ...
+                                                </h6>
+                                            </div>
+                                        </a>
+                                    </div>
+                                </div>
+                                <div class="row row-cols-xl-2 row-cols-1">
+                                    <div class="col mb-3 col-xl-4">
+                                        <img src="../image/dummy-img-600x400.jpg" alt="Vandore Heritage" class="img-fluid rounded-4 h-100" style="aspect-ratio: 5/3;">
+                                    </div>
+                                    <div class="col mb-3 col-xl-8">
+                                        <a href="single_blog.html">
+                                            <div class="d-flex flex-column">
+                                                <div class="d-flex flex-row gap-3">
+                                                    <p data-i18n="jan_01_2025">2025. gada 1. janvāris</p>
+                                                    <p data-i18n="5_min_read">5 minūtes Lasīt</p>
+                                                </div>
+                                                <h6 class="black-1 font-1" data-i18n="how_to_create_a_cozy_outdoor_patio">Kā izveidot mājīgu āra terasi ...
+                                                </h6>
+                                            </div>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="d-flex flex-column gap-4 ps-xl-3">
+                                <h4 class="m-0" data-i18n="our_category">Mūsu kategorija</h4>
+                                <hr class="m-0">
+                                <div class="d-flex flex-column gap-2">
+                                    <div class="d-flex flex-row gap-2">
+                                        <div class="d-flex flex-row gap-2 align-items-center tags accent active">
+                                            <i class="rtmicon rtmicon-arrow-right fs-5"></i>
+                                            <span data-i18n="market_trends">Tirgus tendences</span>
+                                        </div>
+                                        <div class="d-flex flex-row gap-2 align-items-center tags accent">
+                                            <i class="rtmicon rtmicon-arrow-right fs-5"></i>
+                                            <span data-i18n="property_buying_tips">Īpašuma pirkšanas padomi</span>
+                                        </div>
+                                    </div>
+                                    <div class="d-flex flex-row gap-2">
+                                        <div class="d-flex flex-row gap-2 align-items-center tags accent">
+                                            <i class="rtmicon rtmicon-arrow-right fs-5"></i>
+                                            <span data-i18n="selling_strategies">Pārdošanas stratēģijas</span>
+                                        </div>
+                                        <div class="d-flex flex-row gap-2 align-items-center tags accent">
+                                            <i class="rtmicon rtmicon-arrow-right fs-5"></i>
+                                            <span data-i18n="home_improvement">Mājas uzlabošana</span>
+                                        </div>
+                                    </div>
+                                    <div class="d-flex flex-row gap-2">
+                                        <div class="d-flex flex-row gap-2 align-items-center tags accent">
+                                            <i class="rtmicon rtmicon-arrow-right fs-5"></i>
+                                            <span data-i18n="real_estate_news">Nekustamā īpašuma ziņas</span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="d-flex flex-column gap-3 p-5 rounded-2 bg-gray-hover">
+                                <h4 data-i18n="subscribe_our_newsletter">Abonējiet mūsu biļetenu</h4>
+                                <p data-i18n="subscribe_for_exclusive_property_listings_and_market_updates">Abonējiet ekskluzīvus īpašumu sarakstus un tirgus atjauninājumus.</p>
+                                <div class="d-flex flex-column gap-3">
+                                    <div class="toast-container position-fixed bottom-0 end-0 p-3">
+                                        <div id="liveToast" class="toast success_msg_subscribe bg-dark-transparent text-white" role="alert" aria-live="assertive" aria-atomic="true">
+                                            <div class="d-flex">
+                                                <div class="toast-body" data-i18n="your_subscribe_send_successfully">
+                                                    Jūsu abonēšana veiksmīgi nosūta!.
+                                                </div>
+                                                <button type="button" class="btn me-2 m-auto text-white" data-bs-dismiss="toast" aria-label="Close">
+                                                    <i class="fa-solid fa-xmark"></i>
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div>
+                                        <form class="d-flex flex-column h-100 justify-content-center w-100 needs-validation form" novalidate="">
+                                            <input type="text" name="action" value="subscribe" hidden="">
+                                            <div class="input-group gap-3 mb-xl-2 mb-0 position-relative custom-input-group">
+                                                <input type="email" class="form-control mb-xl-0 mb-3 subscribe custom-email-input" placeholder="Your E-mail" name="email" required="">
+                                                <button class="btn btn-accent submit_subscribe rounded-pill custom-submit-button" type="submit">
+                                                    <span data-i18n="subscribe">Abonēt</span>
+                                                </button>
+                                                <div class="invalid-feedback text-white" data-i18n="please_provide_a_valid_email_format_eg_userexamplecom">
+                                                    Lūdzu, norādiet derīgu e -pasta formātu (piemēram, user@example.com).
+                                                </div>
+                                            </div>
+                                        </form>
+
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    </main>
+
+    <footer>
+        <div class="section position-relative bg-black-1" style="height: 90vh;">
+            <div class="row row-cols-xl-2 row-cols-1 h-100">
+                <div class="col col-xl-8 mb-3">
+                    <div class="d-flex flex-column gap-3 justify-content-between h-100">
+                        <div class="d-flex flex-column accent-primary">
+                            <p class="gray" data-i18n="get_contact">Sazināties</p>
+                            <h1 class="fw-normal" data-i18n="infovandoreheritagelv">info@vandoreheritage.lv</h1>
+                        </div>
+                        <img src="../image/logo-footer.png?v=2025" alt="Vandore Heritage" class="img-fluid" width="938">
+                    </div>
+                </div>
+                <div class="col col-xl-4 mb-3">
+                    <div class="d-flex flex-column gap-5 justify-content-between accent-primary h-100">
+                        <div class="d-flex flex-row gap-5">
+                            <ul class="list-unstyled d-flex flex-column gap-3 accent-color">
+                                <li>
+                                    <a href="index.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="home">
+                                        Mājas
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="about.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="about">
+                                        Pret
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="properties.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="properties">
+                                        Īpašības
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="rentals.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="rentals">
+                                        Īre
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="service.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="service">
+                                        Sakārtošana
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="contact.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="contact_us">
+                                        Sazinieties ar mums
+                                    </a>
+                                </li>
+                            </ul>
+                            <div class="d-flex flex-column gap-3">
+                                <a href="https://www.google.com/maps/place/Skanstes+iela+29A,+Vidzemes+priekšpilsēta,+Rīga,+LV-1013,+Latvia" class="link" target="_blank" data-i18n="skanstes_iela_29a91_rga_latvia">
+                                    Skanstes Iela 29A - 91, Rīga, Latvija
+                                </a>
+                                <a href="tel:+37129713030" class="link" data-i18n="371_29_71_3030">
+                                    +371 29 71 3030
+                                </a>
+                            </div>
+                        </div>
+                        <div class="d-flex flex-row gap-3">
+                            <div class="border-end pe-3 border-gray">
+                                <a href="" class="link d-flex flex-row gap-3 align-items-center" data-i18n="terms_conditions">
+                                    Noteikumi un nosacījumi
+                                </a>
+                            </div>
+                            <div>
+                                <a href="" class="link d-flex flex-row gap-3 align-items-center" data-i18n="privacy_notice">
+                                    Paziņojums par privātumu
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+
+    <!-- Back to top button -->
+    <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="rtmicon rtmicon-arrow-up"></i></a>
+
+    <!-- Scripts -->
+    <script src="../js/vendor/jquery.min.js"></script>
+    <script src="../js/vendor/bootstrap.bundle.min.js"></script>
+    <script src="../js/vendor/swiper-bundle.min.js"></script>
+    <script src="../js/script.js"></script>
+    <script src="../js/swiper-script.js"></script>
+    <script src="../js/submit-form.js"></script>
+    <script src="../js/vendor/isotope.pkgd.min.js"></script>
+    <script src="../js/video_embedded.js"></script>
+    <script src="../js/vendor/fslightbox.js"></script>
+    <script src="../js/custom.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.0/oyethemes_onscroll_animation.js"></script>
+
+
+
+</body></html>

--- a/_site/team.html
+++ b/_site/team.html
@@ -1,0 +1,674 @@
+<!DOCTYPE html><html lang="lv" data-sb-object-id="content/pages/team.json"><head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;600&family=Noto+Serif:wght@700&display=swap&subset=latin-ext" rel="stylesheet">
+    <link rel="stylesheet" href="../css/style.css">
+    <link rel="stylesheet" href="../css/custom.css">
+    <link rel="stylesheet" href="../css/fonts.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.2/animation_utility.css">
+    <link rel="icon" type="image/x-icon" href="../image/red_LOGO_Vandore.png?v=2025">
+    <title data-i18n="vandore_heritage_our_team" data-sb-field-path="title">Vandore Heritage - mūsu komanda</title>
+</head>
+
+<body>
+    <!-- Header -->
+    <header class="bg-accent-primary px-5">
+        <nav class="navbar">
+            <div class="container-fluid ps-3 gap-3">
+                <div class="me-auto"></div>
+                <div class="logo-container position-absolute start-50 translate-middle-x" style="margin-top: 2cm;">
+                    <a class="navbar-brand" href="index.html"><img src="../image/red_LOGO_Vandore.png?v=2025" alt="Vandore Heritage" class="img-fluid"></a>
+                </div>
+                <div class="w-max-content" style="margin-top: 0.5cm;">
+                    <button class="btn btn-toggler-accent" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDark" aria-controls="offcanvasDark"><i class="fa-solid fa-bars"></i>
+                        Menu</button>
+
+                    <div class="offcanvas offcanvas-end offcanvas-fullwidth text-bg-dark" tabindex="-1" id="offcanvasDark" aria-labelledby="offcanvasRightLabel">
+                        <div class="offcanvas-header bg-transparent">
+                            <h5 id="offcanvasRightLabel">Menu</h5>
+                            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+                        </div>
+                        <div class="offcanvas-body">
+                            <div class="r-container">
+                                <div class="row row-cols-xl-2 row-cols-1">
+                                    <div class="col col-xl-10 mb-3">
+                                        <div class="d-flex flex-column">
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="01_homepage">01. Mājas lapa</span>
+                                                <img src="../image/img6.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="index.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="02_properties">02. Īpašumi</span>
+                                                <img src="../image/img5.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="properties.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="03_short_form_rentals">03. Īsas formas īre</span>
+                                                <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="rentals.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="04_about_us">04. Par mums</span>
+                                                <img src="../image/img33.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="about.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="05_services">05. Pakalpojumi</span>
+                                                <img src="../image/img18.png" class="img-fluid rounded-3" style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="service.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="06_contact">06. Sazinieties</span>
+                                                <img src="../image/img29.png" class="img-fluid rounded-3 " style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="contact.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                            <hr>
+                                            <div class="navigation">
+                                                <span class="header-text" data-i18n="07_news">07. Jaunumi</span>
+                                                <img src="../image/img26.png" class="img-fluid rounded-3 " style="aspect-ratio: 9/5;" height="175" width="311" alt="Vandore Heritage">
+                                                <a href="blog.html" class="d-flex" style="justify-self: end;">
+                                                    <i class="rtmicon rtmicon-arrow-right fs-1 fw-bold"></i>
+                                                </a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col col-xl-2 mb-3">
+                                        <div class="d-flex flex-column gap-5 accent-primary text-end">
+                                           <div class="d-flex flex-column gap-4">
+                                                <h6 data-i18n="riga_latvia">Rīga, Latvija</h6>
+                                                <div class="d-flex flex-column gap-3">
+                                                    <span data-i18n="skanstes_iela_29a91_rga_latvia">
+                                                        Skanstes Iela 29A - 91, Rīga, Latvija
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </nav>
+    </header>
+    <!-- End Header -->
+
+    <!-- Main -->
+    <main>
+        <!-- Banner -->
+        <div class="section position-relative bg-attach-cover">
+            <div class="r-container position-relative h-100">
+                <div class="position-absolute top-0 start-0 end-0 bottom-0 h-100 w-100" style="margin-top: 10rem;">
+                    <div class="row row-cols-2">
+                        <div class="col-3 col-xl-2"></div>
+                        <div class="col-9 col-xl-10">
+                            <img src="../image/dummy-img-1920x900.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Vandore Heritage">
+                        </div>
+                    </div>
+                </div>
+                <div class="d-flex flex-column gap-5 justify-content-between scrollanimation animated fadeInLeft adr-7 h-100 padding-custom">
+                    <div class="d-flex flex-column gap-2 h-100">
+                        <div><h1 class="display" style="max-width: 700px;" data-i18n="our_team" data-sb-field-path="heroHeading">Mūsu komanda</h1>
+                        <div class="row row-xl-cols-2 row-cols-1">
+                            <div class="col col-xl-2">
+                                <div class="d-flex flex-column gap-2 align-items-xl-center align-items-start">
+                                    <p data-i18n="meet_our_dedicated_team_of_real_estate_experts_committed_to_providing_exceptional_service" data-sb-field-path="heroSubheading">Iepazīstieties ar mūsu specializēto nekustamā īpašuma ekspertu komandu, apņēmusies nodrošināt 
+Izcils serviss.</p></div>
+                                    <div class="devider"></div>
+                                </div>
+                            </div>
+                            <div class="col col-xl-10"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Section Our Team -->
+        <div class="section">
+            <div class="r-container d-flex flex-column gap-5" style="margin-bottom: 6em;">
+                <div class="row row-cols-xl-2 row-cols-1 align-items-end">
+                    <div class="col mb-3 scrollanimation animated fadeInLeft adr-7">
+                        <h3 style="max-width: 600px;" data-i18n="we_are_vandore_heritage_professional_team">Mēs esam Vandore Heritage Professional komanda</h3>
+                    </div>
+                    <div class="col mb-3 scrollanimation animated fadeInDown adr-7">
+                        <div class="d-flex flex-column gap-2 align-items-end">
+                            <p data-i18n="we_represent_properties_that_speak_and_clients_who_value_being_heard_this_isnt_just_business_its_an_attitude">Mēs pārstāvam īpašības, kas runā, un klienti, kuri vērtē tiek uzklausīti. Tas nav tikai bizness. Tā ir attieksme.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="row row-cols-xl-3 row-cols-1" data-sb-field-path="team">
+                    <div class="col mb-4">
+                        <div class="card d-flex flex-column h-100 position-relative">
+                            <img src="../image/dummy-img-600x700.jpg" class="img-fluid h-100 rounded-2" style="aspect-ratio: 6/7;" alt="Vandore Heritage" data-sb-field-path="team[0].image">
+                            <div class="d-flex flex-column gap-5 rounded-2 p-4 bg-gray-hover mx-4" style="margin-top: -105px;">
+                                <div class="d-flex flex-column gap-2">
+                                    <h4 data-i18n="dolfs_mrti_krauklis" data-sb-field-path="team[0].name">Ādolfs Mārtiņš Krauklis</h4>
+                                    <span data-i18n="cofounder" data-sb-field-path="team[0].role">Līdzdibinātājs</span>
+                                </div>
+                                <div class="social-container" style="border-bottom-right-radius: 20px;">
+                                    <a href="https://www.facebook.com/share/1AwoA2Vb1U/?mibextid=wwXIfr" class="social-item" target="_blank">
+                                        <i class="fa-brands fa-xs fa-facebook-f"></i>
+                                    </a>
+                                    <a href="https://www.instagram.com/vandoreheritage" class="social-item" target="_blank">
+                                        <i class="fa-brands fa-xs fa-instagram"></i>
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col mb-4">
+                        <div class="card d-flex flex-column h-100 position-relative">
+                            <img src="../image/dummy-img-600x700.jpg" class="img-fluid h-100 rounded-2" style="aspect-ratio: 6/7;" alt="Vandore Heritage" data-sb-field-path="team[1].image">
+                            <div class="d-flex flex-column gap-5 rounded-2 p-4 bg-gray-hover mx-4" style="margin-top: -105px;">
+                                <div class="d-flex flex-column gap-2">
+                                    <h4 data-i18n="roberts_punka" data-sb-field-path="team[1].name">Roberts panka</h4>
+                                    <span data-i18n="cofounder" data-sb-field-path="team[1].role">Līdzdibinātājs</span>
+                                </div>
+                                <div class="social-container" style="border-bottom-right-radius: 20px;">
+                                    <a href="https://www.facebook.com/share/1AwoA2Vb1U/?mibextid=wwXIfr" class="social-item" target="_blank">
+                                        <i class="fa-brands fa-xs fa-facebook-f"></i>
+                                    </a>
+                                    <a href="https://www.instagram.com/vandoreheritage" class="social-item" target="_blank">
+                                        <i class="fa-brands fa-xs fa-instagram"></i>
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Section Featured Properties -->
+        <div class="section bg-attach-cover" style="background-image: url(../image/bg_feature.png);">
+            <div class="r-container d-flex flex-column gap-5">
+                <div class="row row-cols-xl-2 row-cols-1 align-items-end">
+                    <div class="col mb-3 scrollanimation animated fadeInLeft adr-7">
+                        <h3 style="max-width: 400px;" data-i18n="explore_your_perfect_home">Izpētiet savu ideālo māju</h3>
+                    </div>
+                    <div class="col mb-3 scrollanimation animated fadeInDown adr-7">
+                        <div class="d-flex flex-column gap-2 align-items-end">
+                            <div class="w-max-content" style="justify-self: end;">
+                                <a href="property_detail.html" class="btn btn-accent-outline d-flex flex-row gap-2 justify-content-center">
+                                    <span data-i18n="explore_more">Izpētiet vairāk</span>
+                                    <i class="rtmicon rtmicon-arrow-up-right fw-bold"></i>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="tab-container">
+                    <div class="tab-content">
+                        <div class="content active" id="feature-1">
+                            <div class="d-flex flex-column h-100 position-relative">
+                                <div class="position-absolute end-0 top-0 rounded-2 d-flex flex-row gap-1 mt-3 me-3 px-2 py-1 bg-accent-primary align-items-center">
+                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                    <span data-i18n="49">(4.9)</span>
+                                </div>
+                                <img src="../image/dummy-img-600x400.jpg" class="img-fluid h-100" style="aspect-ratio: 3/2;" alt="Vandore Heritage">
+                                <a href="">
+                                    <div class="d-flex flex-column gap-5 rounded-2 p-4 bg-gray-hover mx-4 black-1" style="margin-top: -105px;">
+                                        <div class="d-flex flex-row justify-content-between">
+                                            <div class="d-flex flex-column gap-2">
+                                                <div class="d-flex flex-row gap-2 align-items-center">
+                                                    <i class="rtmicon rtmicon-location fw-bold"></i>
+                                                    <span data-i18n="beverly_hills_california">Beverlihils, Kalifornijā</span>
+                                                </div>
+                                                <h4 data-i18n="luxury_home_advisors">Luksusa mājas konsultanti</h4>
+                                            </div>
+                                            <h4 data-i18n="569k">569 000 USD</h4>
+                                        </div>
+                                        <div class="d-flex flex-row gap-3">
+                                            <div class="d-flex flex-row gap-2 link">
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="24" fill="CurrentColor" data-name="Layer 3" viewBox="0 0 500 500">
+                                                    <path d="M440.77,233.93V80.84c0-25.44-19.98-46.15-44.52-46.15l-292.4-.07c-24.53,0-44.51,20.7-44.53,46.13l-.08,153.17c-28.16,7.53-49.12,33.8-49.15,65.26l-.08,98.51c0,4.89,1.94,9.59,5.4,13.06,3.47,3.46,8.16,5.41,13.06,5.41h7.4c-.7,1.95-1.24,3.98-1.24,6.17v24.62c.01,10.19,8.28,18.45,18.47,18.45h.01c10.19,0,18.45-8.27,18.45-18.47v-24.62c-.01-2.18-.56-4.2-1.25-6.14h359.41c-.7,1.95-1.24,3.98-1.24,6.17v24.62c.01,10.19,8.28,18.45,18.47,18.45h.01c10.19,0,18.45-8.27,18.45-18.47v-24.62c-.01-2.18-.56-4.2-1.25-6.14h7.39c10.19,0,18.46-8.27,18.46-18.46v-98.41c0-31.51-21.01-57.84-49.23-65.35ZM330,231.54h-160v-55.38c0-3.39,2.76-6.15,6.15-6.15h147.69c3.39,0,6.15,2.76,6.15,6.15v55.38ZM96.24,80.77c0-5,3.49-9.23,7.61-9.23l292.4.07c4.12,0,7.6,4.23,7.6,9.23v150.7h-36.92v-55.38c0-23.75-19.33-43.08-43.08-43.08h-147.69c-23.75,0-43.08,19.33-43.08,43.08v55.38h-36.91l.07-150.77ZM47.01,299.19c.01-16.95,12.8-30.73,28.5-30.73l349.09.05c15.71,0,28.49,13.8,28.49,30.77v79.95H46.94l.07-80.04Z" stroke-width="0"></path>
+                                                </svg>
+                                                <span data-i18n="4_bads">4 sliktas</span>
+                                            </div>
+                                            <div class="d-flex flex-row gap-2 link">
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="24" fill="CurrentColor" data-name="Layer 3" viewBox="0 0 500 500">
+                                                    <path d="M59.24,426.08v8.56c0,10.19,8.27,18.45,18.47,18.45h.01c10.19,0,18.45-8.27,18.45-18.47v-6.19s307.7.04,307.7.04v6.17c0,10.19,8.27,18.45,18.47,18.45h.01c10.19,0,18.45-8.27,18.45-18.47v-8.52c28.15-7.54,49.11-33.81,49.14-65.25l.06-73.87c.01-11.51-4.47-22.33-12.6-30.48-8.14-8.15-18.97-12.63-30.48-12.63H96.17V89.99c-.01-3.39,2.75-6.15,6.14-6.15h98.47c3.39,0,6.15,2.76,6.15,6.15v6.15h-6.15c-23.75,0-43.08,19.33-43.08,43.08v24.62c0,10.19,8.27,18.46,18.46,18.46h98.47c10.19,0,18.46-8.27,18.46-18.46v-24.62c0-23.75-19.33-43.08-43.08-43.08h-6.15v-6.15c0-23.75-19.33-43.08-43.08-43.08h-98.47c-23.75,0-43.08,19.33-43.08,43.08v153.85s-6.15,0-6.15,0c-23.75,0-43.08,19.33-43.08,43.08v73.8c0,31.51,21.01,57.85,49.24,65.35ZM256.17,139.23v6.15h-61.54v-6.15c0-3.39,2.76-6.15,6.15-6.15h49.23c3.39,0,6.15,2.76,6.15,6.15ZM46.92,286.92c0-3.39,2.76-6.15,6.15-6.15h393.84c2.22,0,3.68,1.13,4.35,1.8s1.8,2.14,1.8,4.36l-.06,73.87c-.01,16.95-12.8,30.73-28.5,30.73l-349.1-.05c-15.71,0-28.49-13.8-28.49-30.77v-73.8Z" stroke-width="0"></path>
+                                                </svg>
+                                                <span data-i18n="5_bath">5 vanna</span>
+                                            </div>
+                                            <div class="d-flex flex-row gap-2 link">
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="24" fill="CurrentColor" data-name="Layer 3" viewBox="0 0 500 500">
+                                                    <path d="M446.92,10H53.08c-23.75,0-43.08,19.33-43.08,43.08v393.85c0,23.75,19.33,43.08,43.08,43.08h393.85c23.75,0,43.08-19.33,43.08-43.08V53.08c0-23.75-19.33-43.08-43.08-43.08ZM446.92,453.08h-104.62v-68.86c0-10.19-8.27-18.46-18.46-18.46s-18.46,8.27-18.46,18.46v68.86H53.08c-3.39,0-6.15-2.76-6.15-6.15v-179.7c1.94.7,3.97,1.24,6.15,1.24h73.85c10.19,0,18.46-8.27,18.46-18.46s-8.27-18.46-18.46-18.46H53.08c-2.18,0-4.21.55-6.15,1.24V53.08c0-3.39,2.76-6.15,6.15-6.15h178.47v68.86c0,10.19,8.25,18.46,18.45,18.46s18.46-8.27,18.46-18.46V46.92h178.46c3.39,0,6.15,2.76,6.15,6.15v178.46h-184.62v-39.77c0-10.19-8.27-18.46-18.46-18.46s-18.46,8.27-18.46,18.46v39.77h-30.77c-10.19,0-18.46,8.27-18.46,18.46s8.27,18.46,18.46,18.46h104.62v39.77c0,10.19,8.25,18.46,18.45,18.46s18.46-8.26,18.46-18.46v-39.77h110.77v178.46c0,3.39-2.76,6.15-6.15,6.15Z" stroke-width="0"></path>
+                                                </svg>
+                                                <span data-i18n="10000_sqft">10 000 kv.ft</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </a>
+                            </div>
+                        </div>
+                        <div class="content" id="feature-2">
+                            <div class="d-flex flex-column h-100 position-relative">
+                                <div class="position-absolute end-0 top-0 rounded-2 d-flex flex-row gap-1 mt-3 me-3 px-2 py-1 bg-accent-primary align-items-center">
+                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                    <span data-i18n="47">(4.7.)</span>
+                                </div>
+                                <img src="../image/dummy-img-600x400.jpg" class="img-fluid h-100" style="aspect-ratio: 3/2;" alt="Vandore Heritage">
+                                <a href="">
+                                    <div class="d-flex flex-column gap-5 rounded-2 p-4 bg-gray-hover mx-4 black-1" style="margin-top: -105px;">
+                                        <div class="d-flex flex-row justify-content-between">
+                                            <div class="d-flex flex-column gap-2">
+                                                <div class="d-flex flex-row gap-2 align-items-center">
+                                                    <i class="rtmicon rtmicon-location fw-bold"></i>
+                                                    <span data-i18n="beverly_hills_california">Beverlihils, Kalifornijā</span>
+                                                </div>
+                                                <h4 data-i18n="sunset_valley_retreat">Saulrieta ielejas atkāpšanās</h4>
+                                            </div>
+                                            <h4 data-i18n="669k">669 000 USD</h4>
+                                        </div>
+                                        <div class="d-flex flex-row gap-3">
+                                            <div class="d-flex flex-row gap-2 link">
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="24" fill="CurrentColor" data-name="Layer 3" viewBox="0 0 500 500">
+                                                    <path d="M440.77,233.93V80.84c0-25.44-19.98-46.15-44.52-46.15l-292.4-.07c-24.53,0-44.51,20.7-44.53,46.13l-.08,153.17c-28.16,7.53-49.12,33.8-49.15,65.26l-.08,98.51c0,4.89,1.94,9.59,5.4,13.06,3.47,3.46,8.16,5.41,13.06,5.41h7.4c-.7,1.95-1.24,3.98-1.24,6.17v24.62c.01,10.19,8.28,18.45,18.47,18.45h.01c10.19,0,18.45-8.27,18.45-18.47v-24.62c-.01-2.18-.56-4.2-1.25-6.14h359.41c-.7,1.95-1.24,3.98-1.24,6.17v24.62c.01,10.19,8.28,18.45,18.47,18.45h.01c10.19,0,18.45-8.27,18.45-18.47v-24.62c-.01-2.18-.56-4.2-1.25-6.14h7.39c10.19,0,18.46-8.27,18.46-18.46v-98.41c0-31.51-21.01-57.84-49.23-65.35ZM330,231.54h-160v-55.38c0-3.39,2.76-6.15,6.15-6.15h147.69c3.39,0,6.15,2.76,6.15,6.15v55.38ZM96.24,80.77c0-5,3.49-9.23,7.61-9.23l292.4.07c4.12,0,7.6,4.23,7.6,9.23v150.7h-36.92v-55.38c0-23.75-19.33-43.08-43.08-43.08h-147.69c-23.75,0-43.08,19.33-43.08,43.08v55.38h-36.91l.07-150.77ZM47.01,299.19c.01-16.95,12.8-30.73,28.5-30.73l349.09.05c15.71,0,28.49,13.8,28.49,30.77v79.95H46.94l.07-80.04Z" stroke-width="0"></path>
+                                                </svg>
+                                                <span data-i18n="5_bads">5 sliktas</span>
+                                            </div>
+                                            <div class="d-flex flex-row gap-2 link">
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="24" fill="CurrentColor" data-name="Layer 3" viewBox="0 0 500 500">
+                                                    <path d="M59.24,426.08v8.56c0,10.19,8.27,18.45,18.47,18.45h.01c10.19,0,18.45-8.27,18.45-18.47v-6.19s307.7.04,307.7.04v6.17c0,10.19,8.27,18.45,18.47,18.45h.01c10.19,0,18.45-8.27,18.45-18.47v-8.52c28.15-7.54,49.11-33.81,49.14-65.25l.06-73.87c.01-11.51-4.47-22.33-12.6-30.48-8.14-8.15-18.97-12.63-30.48-12.63H96.17V89.99c-.01-3.39,2.75-6.15,6.14-6.15h98.47c3.39,0,6.15,2.76,6.15,6.15v6.15h-6.15c-23.75,0-43.08,19.33-43.08,43.08v24.62c0,10.19,8.27,18.46,18.46,18.46h98.47c10.19,0,18.46-8.27,18.46-18.46v-24.62c0-23.75-19.33-43.08-43.08-43.08h-6.15v-6.15c0-23.75-19.33-43.08-43.08-43.08h-98.47c-23.75,0-43.08,19.33-43.08,43.08v153.85s-6.15,0-6.15,0c-23.75,0-43.08,19.33-43.08,43.08v73.8c0,31.51,21.01,57.85,49.24,65.35ZM256.17,139.23v6.15h-61.54v-6.15c0-3.39,2.76-6.15,6.15-6.15h49.23c3.39,0,6.15,2.76,6.15,6.15ZM46.92,286.92c0-3.39,2.76-6.15,6.15-6.15h393.84c2.22,0,3.68,1.13,4.35,1.8s1.8,2.14,1.8,4.36l-.06,73.87c-.01,16.95-12.8,30.73-28.5,30.73l-349.1-.05c-15.71,0-28.49-13.8-28.49-30.77v-73.8Z" stroke-width="0"></path>
+                                                </svg>
+                                                <span data-i18n="3_bath">3 vanna</span>
+                                            </div>
+                                            <div class="d-flex flex-row gap-2 link">
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="24" fill="CurrentColor" data-name="Layer 3" viewBox="0 0 500 500">
+                                                    <path d="M446.92,10H53.08c-23.75,0-43.08,19.33-43.08,43.08v393.85c0,23.75,19.33,43.08,43.08,43.08h393.85c23.75,0,43.08-19.33,43.08-43.08V53.08c0-23.75-19.33-43.08-43.08-43.08ZM446.92,453.08h-104.62v-68.86c0-10.19-8.27-18.46-18.46-18.46s-18.46,8.27-18.46,18.46v68.86H53.08c-3.39,0-6.15-2.76-6.15-6.15v-179.7c1.94.7,3.97,1.24,6.15,1.24h73.85c10.19,0,18.46-8.27,18.46-18.46s-8.27-18.46-18.46-18.46H53.08c-2.18,0-4.21.55-6.15,1.24V53.08c0-3.39,2.76-6.15,6.15-6.15h178.47v68.86c0,10.19,8.25,18.46,18.45,18.46s18.46-8.27,18.46-18.46V46.92h178.46c3.39,0,6.15,2.76,6.15,6.15v178.46h-184.62v-39.77c0-10.19-8.27-18.46-18.46-18.46s-18.46,8.27-18.46,18.46v39.77h-30.77c-10.19,0-18.46,8.27-18.46,18.46s8.27,18.46,18.46,18.46h104.62v39.77c0,10.19,8.25,18.46,18.45,18.46s18.46-8.26,18.46-18.46v-39.77h110.77v178.46c0,3.39-2.76,6.15-6.15,6.15Z" stroke-width="0"></path>
+                                                </svg>
+                                                <span data-i18n="20000_sqft">20 000 kv.ft</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </a>
+                            </div>
+                        </div>
+                        <div class="content" id="feature-3">
+                            <div class="d-flex flex-column h-100 position-relative">
+                                <div class="position-absolute end-0 top-0 rounded-2 d-flex flex-row gap-1 mt-3 me-3 px-2 py-1 bg-accent-primary align-items-center">
+                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                    <span data-i18n="48">(4.8)</span>
+                                </div>
+                                <img src="../image/dummy-img-600x400.jpg" class="img-fluid h-100" style="aspect-ratio: 3/2;" alt="Vandore Heritage">
+                                <a href="">
+                                    <div class="d-flex flex-column gap-5 rounded-2 p-4 bg-gray-hover mx-4 black-1" style="margin-top: -105px;">
+                                        <div class="d-flex flex-row justify-content-between">
+                                            <div class="d-flex flex-column gap-2">
+                                                <div class="d-flex flex-row gap-2 align-items-center">
+                                                    <i class="rtmicon rtmicon-location fw-bold"></i>
+                                                    <span data-i18n="beverly_hills_california">Beverlihils, Kalifornijā</span>
+                                                </div>
+                                                <h4 data-i18n="crystal_bay_residences">Crystal Bay dzīvesvietas</h4>
+                                            </div>
+                                            <h4 data-i18n="769k">769 000 USD</h4>
+                                        </div>
+                                        <div class="d-flex flex-row gap-3">
+                                            <div class="d-flex flex-row gap-2 link">
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="24" fill="CurrentColor" data-name="Layer 3" viewBox="0 0 500 500">
+                                                    <path d="M440.77,233.93V80.84c0-25.44-19.98-46.15-44.52-46.15l-292.4-.07c-24.53,0-44.51,20.7-44.53,46.13l-.08,153.17c-28.16,7.53-49.12,33.8-49.15,65.26l-.08,98.51c0,4.89,1.94,9.59,5.4,13.06,3.47,3.46,8.16,5.41,13.06,5.41h7.4c-.7,1.95-1.24,3.98-1.24,6.17v24.62c.01,10.19,8.28,18.45,18.47,18.45h.01c10.19,0,18.45-8.27,18.45-18.47v-24.62c-.01-2.18-.56-4.2-1.25-6.14h359.41c-.7,1.95-1.24,3.98-1.24,6.17v24.62c.01,10.19,8.28,18.45,18.47,18.45h.01c10.19,0,18.45-8.27,18.45-18.47v-24.62c-.01-2.18-.56-4.2-1.25-6.14h7.39c10.19,0,18.46-8.27,18.46-18.46v-98.41c0-31.51-21.01-57.84-49.23-65.35ZM330,231.54h-160v-55.38c0-3.39,2.76-6.15,6.15-6.15h147.69c3.39,0,6.15,2.76,6.15,6.15v55.38ZM96.24,80.77c0-5,3.49-9.23,7.61-9.23l292.4.07c4.12,0,7.6,4.23,7.6,9.23v150.7h-36.92v-55.38c0-23.75-19.33-43.08-43.08-43.08h-147.69c-23.75,0-43.08,19.33-43.08,43.08v55.38h-36.91l.07-150.77ZM47.01,299.19c.01-16.95,12.8-30.73,28.5-30.73l349.09.05c15.71,0,28.49,13.8,28.49,30.77v79.95H46.94l.07-80.04Z" stroke-width="0"></path>
+                                                </svg>
+                                                <span data-i18n="6_bads">6 sliktas</span>
+                                            </div>
+                                            <div class="d-flex flex-row gap-2 link">
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="24" fill="CurrentColor" data-name="Layer 3" viewBox="0 0 500 500">
+                                                    <path d="M59.24,426.08v8.56c0,10.19,8.27,18.45,18.47,18.45h.01c10.19,0,18.45-8.27,18.45-18.47v-6.19s307.7.04,307.7.04v6.17c0,10.19,8.27,18.45,18.47,18.45h.01c10.19,0,18.45-8.27,18.45-18.47v-8.52c28.15-7.54,49.11-33.81,49.14-65.25l.06-73.87c.01-11.51-4.47-22.33-12.6-30.48-8.14-8.15-18.97-12.63-30.48-12.63H96.17V89.99c-.01-3.39,2.75-6.15,6.14-6.15h98.47c3.39,0,6.15,2.76,6.15,6.15v6.15h-6.15c-23.75,0-43.08,19.33-43.08,43.08v24.62c0,10.19,8.27,18.46,18.46,18.46h98.47c10.19,0,18.46-8.27,18.46-18.46v-24.62c0-23.75-19.33-43.08-43.08-43.08h-6.15v-6.15c0-23.75-19.33-43.08-43.08-43.08h-98.47c-23.75,0-43.08,19.33-43.08,43.08v153.85s-6.15,0-6.15,0c-23.75,0-43.08,19.33-43.08,43.08v73.8c0,31.51,21.01,57.85,49.24,65.35ZM256.17,139.23v6.15h-61.54v-6.15c0-3.39,2.76-6.15,6.15-6.15h49.23c3.39,0,6.15,2.76,6.15,6.15ZM46.92,286.92c0-3.39,2.76-6.15,6.15-6.15h393.84c2.22,0,3.68,1.13,4.35,1.8s1.8,2.14,1.8,4.36l-.06,73.87c-.01,16.95-12.8,30.73-28.5,30.73l-349.1-.05c-15.71,0-28.49-13.8-28.49-30.77v-73.8Z" stroke-width="0"></path>
+                                                </svg>
+                                                <span data-i18n="5_bath">5 vanna</span>
+                                            </div>
+                                            <div class="d-flex flex-row gap-2 link">
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="24" fill="CurrentColor" data-name="Layer 3" viewBox="0 0 500 500">
+                                                    <path d="M446.92,10H53.08c-23.75,0-43.08,19.33-43.08,43.08v393.85c0,23.75,19.33,43.08,43.08,43.08h393.85c23.75,0,43.08-19.33,43.08-43.08V53.08c0-23.75-19.33-43.08-43.08-43.08ZM446.92,453.08h-104.62v-68.86c0-10.19-8.27-18.46-18.46-18.46s-18.46,8.27-18.46,18.46v68.86H53.08c-3.39,0-6.15-2.76-6.15-6.15v-179.7c1.94.7,3.97,1.24,6.15,1.24h73.85c10.19,0,18.46-8.27,18.46-18.46s-8.27-18.46-18.46-18.46H53.08c-2.18,0-4.21.55-6.15,1.24V53.08c0-3.39,2.76-6.15,6.15-6.15h178.47v68.86c0,10.19,8.25,18.46,18.45,18.46s18.46-8.27,18.46-18.46V46.92h178.46c3.39,0,6.15,2.76,6.15,6.15v178.46h-184.62v-39.77c0-10.19-8.27-18.46-18.46-18.46s-18.46,8.27-18.46,18.46v39.77h-30.77c-10.19,0-18.46,8.27-18.46,18.46s8.27,18.46,18.46,18.46h104.62v39.77c0,10.19,8.25,18.46,18.45,18.46s18.46-8.26,18.46-18.46v-39.77h110.77v178.46c0,3.39-2.76,6.15-6.15,6.15Z" stroke-width="0"></path>
+                                                </svg>
+                                                <span data-i18n="30000_sqft">30 000 kv.ft</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </a>
+                            </div>
+                        </div>
+                        <div class="content" id="feature-4">
+                            <div class="d-flex flex-column h-100 position-relative">
+                                <div class="position-absolute end-0 top-0 rounded-2 d-flex flex-row gap-1 mt-3 me-3 px-2 py-1 bg-accent-primary align-items-center">
+                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                    <span data-i18n="46">(4.6.)</span>
+                                </div>
+                                <img src="../image/dummy-img-600x400.jpg" class="img-fluid h-100" style="aspect-ratio: 3/2;" alt="Vandore Heritage">
+                                <a href="">
+                                    <div class="d-flex flex-column gap-5 rounded-2 p-4 bg-gray-hover mx-4 black-1" style="margin-top: -105px;">
+                                        <div class="d-flex flex-row justify-content-between">
+                                            <div class="d-flex flex-column gap-2">
+                                                <div class="d-flex flex-row gap-2 align-items-center">
+                                                    <i class="rtmicon rtmicon-location fw-bold"></i>
+                                                    <span data-i18n="beverly_hills_california">Beverlihils, Kalifornijā</span>
+                                                </div>
+                                                <h4 data-i18n="harbor_bay_residences">Ostas līča dzīvesvietas</h4>
+                                            </div>
+                                            <h4 data-i18n="549k">USD 549K</h4>
+                                        </div>
+                                        <div class="d-flex flex-row gap-3">
+                                            <div class="d-flex flex-row gap-2 link">
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="24" fill="CurrentColor" data-name="Layer 3" viewBox="0 0 500 500">
+                                                    <path d="M440.77,233.93V80.84c0-25.44-19.98-46.15-44.52-46.15l-292.4-.07c-24.53,0-44.51,20.7-44.53,46.13l-.08,153.17c-28.16,7.53-49.12,33.8-49.15,65.26l-.08,98.51c0,4.89,1.94,9.59,5.4,13.06,3.47,3.46,8.16,5.41,13.06,5.41h7.4c-.7,1.95-1.24,3.98-1.24,6.17v24.62c.01,10.19,8.28,18.45,18.47,18.45h.01c10.19,0,18.45-8.27,18.45-18.47v-24.62c-.01-2.18-.56-4.2-1.25-6.14h359.41c-.7,1.95-1.24,3.98-1.24,6.17v24.62c.01,10.19,8.28,18.45,18.47,18.45h.01c10.19,0,18.45-8.27,18.45-18.47v-24.62c-.01-2.18-.56-4.2-1.25-6.14h7.39c10.19,0,18.46-8.27,18.46-18.46v-98.41c0-31.51-21.01-57.84-49.23-65.35ZM330,231.54h-160v-55.38c0-3.39,2.76-6.15,6.15-6.15h147.69c3.39,0,6.15,2.76,6.15,6.15v55.38ZM96.24,80.77c0-5,3.49-9.23,7.61-9.23l292.4.07c4.12,0,7.6,4.23,7.6,9.23v150.7h-36.92v-55.38c0-23.75-19.33-43.08-43.08-43.08h-147.69c-23.75,0-43.08,19.33-43.08,43.08v55.38h-36.91l.07-150.77ZM47.01,299.19c.01-16.95,12.8-30.73,28.5-30.73l349.09.05c15.71,0,28.49,13.8,28.49,30.77v79.95H46.94l.07-80.04Z" stroke-width="0"></path>
+                                                </svg>
+                                                <span data-i18n="3_bads">3 sliktas</span>
+                                            </div>
+                                            <div class="d-flex flex-row gap-2 link">
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="24" fill="CurrentColor" data-name="Layer 3" viewBox="0 0 500 500">
+                                                    <path d="M59.24,426.08v8.56c0,10.19,8.27,18.45,18.47,18.45h.01c10.19,0,18.45-8.27,18.45-18.47v-6.19s307.7.04,307.7.04v6.17c0,10.19,8.27,18.45,18.47,18.45h.01c10.19,0,18.45-8.27,18.45-18.47v-8.52c28.15-7.54,49.11-33.81,49.14-65.25l.06-73.87c.01-11.51-4.47-22.33-12.6-30.48-8.14-8.15-18.97-12.63-30.48-12.63H96.17V89.99c-.01-3.39,2.75-6.15,6.14-6.15h98.47c3.39,0,6.15,2.76,6.15,6.15v6.15h-6.15c-23.75,0-43.08,19.33-43.08,43.08v24.62c0,10.19,8.27,18.46,18.46,18.46h98.47c10.19,0,18.46-8.27,18.46-18.46v-24.62c0-23.75-19.33-43.08-43.08-43.08h-6.15v-6.15c0-23.75-19.33-43.08-43.08-43.08h-98.47c-23.75,0-43.08,19.33-43.08,43.08v153.85s-6.15,0-6.15,0c-23.75,0-43.08,19.33-43.08,43.08v73.8c0,31.51,21.01,57.85,49.24,65.35ZM256.17,139.23v6.15h-61.54v-6.15c0-3.39,2.76-6.15,6.15-6.15h49.23c3.39,0,6.15,2.76,6.15,6.15ZM46.92,286.92c0-3.39,2.76-6.15,6.15-6.15h393.84c2.22,0,3.68,1.13,4.35,1.8s1.8,2.14,1.8,4.36l-.06,73.87c-.01,16.95-12.8,30.73-28.5,30.73l-349.1-.05c-15.71,0-28.49-13.8-28.49-30.77v-73.8Z" stroke-width="0"></path>
+                                                </svg>
+                                                <span data-i18n="2_bath">2 vanna</span>
+                                            </div>
+                                            <div class="d-flex flex-row gap-2 link">
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="24" fill="CurrentColor" data-name="Layer 3" viewBox="0 0 500 500">
+                                                    <path d="M446.92,10H53.08c-23.75,0-43.08,19.33-43.08,43.08v393.85c0,23.75,19.33,43.08,43.08,43.08h393.85c23.75,0,43.08-19.33,43.08-43.08V53.08c0-23.75-19.33-43.08-43.08-43.08ZM446.92,453.08h-104.62v-68.86c0-10.19-8.27-18.46-18.46-18.46s-18.46,8.27-18.46,18.46v68.86H53.08c-3.39,0-6.15-2.76-6.15-6.15v-179.7c1.94.7,3.97,1.24,6.15,1.24h73.85c10.19,0,18.46-8.27,18.46-18.46s-8.27-18.46-18.46-18.46H53.08c-2.18,0-4.21.55-6.15,1.24V53.08c0-3.39,2.76-6.15,6.15-6.15h178.47v68.86c0,10.19,8.25,18.46,18.45,18.46s18.46-8.27,18.46-18.46V46.92h178.46c3.39,0,6.15,2.76,6.15,6.15v178.46h-184.62v-39.77c0-10.19-8.27-18.46-18.46-18.46s-18.46,8.27-18.46,18.46v39.77h-30.77c-10.19,0-18.46,8.27-18.46,18.46s8.27,18.46,18.46,18.46h104.62v39.77c0,10.19,8.25,18.46,18.45,18.46s18.46-8.26,18.46-18.46v-39.77h110.77v178.46c0,3.39-2.76,6.15-6.15,6.15Z" stroke-width="0"></path>
+                                                </svg>
+                                                <span data-i18n="5000_sqft">5000 kv.ft</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="tabs">
+                        <div class="tab active" data-tab="feature-1">
+                            <div class="position-relative overflow-hidden">
+                                <div class="position-absolute end-0 top-0 rounded-2 d-flex flex-row gap-1 mt-3 me-3 px-2 py-1 bg-accent-primary black-1 align-items-center">
+                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                    <span data-i18n="49">(4.9)</span>
+                                </div>
+                                <img src="../image/dummy-img-600x400.jpg" class="img-fluid w-100 h-100" style="aspect-ratio: 3/2;" alt="Vandore Heritage">
+                            </div>
+                        </div>
+                        <div class="tab" data-tab="feature-2">
+                            <div class="position-relative overflow-hidden">
+                                <div class="position-absolute end-0 top-0 rounded-2 d-flex flex-row gap-1 mt-3 me-3 px-2 py-1 bg-accent-primary black-1 align-items-center">
+                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                    <span data-i18n="47">(4.7.)</span>
+                                </div>
+                                <img src="../image/dummy-img-600x400.jpg" class="img-fluid w-100 h-100" style="aspect-ratio: 3/2;" alt="Vandore Heritage">
+                            </div>
+                        </div>
+                        <div class="tab" data-tab="feature-3">
+                            <div class="position-relative overflow-hidden">
+                                <div class="position-absolute end-0 top-0 rounded-2 d-flex flex-row gap-1 mt-3 me-3 px-2 py-1 bg-accent-primary black-1 align-items-center">
+                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                    <span data-i18n="48">(4.8)</span>
+                                </div>
+                                <img src="../image/dummy-img-600x400.jpg" class="img-fluid w-100 h-100" style="aspect-ratio: 3/2;" alt="Vandore Heritage">
+                            </div>
+                        </div>
+                        <div class="tab" data-tab="feature-4">
+                            <div class="position-relative overflow-hidden">
+                                <div class="position-absolute end-0 top-0 rounded-2 d-flex flex-row gap-1 mt-3 me-3 px-2 py-1 bg-accent-primary black-1 align-items-center">
+                                    <i class="fa-solid fa-star" style="color: #FFD43B;"></i>
+                                    <span data-i18n="46">(4.6.)</span>
+                                </div>
+                                <img src="../image/dummy-img-600x400.jpg" class="img-fluid w-100 h-100" style="aspect-ratio: 3/2;" alt="Vandore Heritage">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Section How It Work -->
+        <div class="section">
+            <div class="r-container d-flex flex-column" style="gap: 140px;">
+                <div class="d-flex flex-xl-row flex-column gap-5 justify-content-between align-items-center position-relative  scrollanimation animated fadeIn adr-7">
+                    <div class="devider-progress"></div>
+                    <div class="d-flex flex-column gap-5 align-items-center">
+                        <div class="icon-box active position-relative">
+                            <i class="rtmicon rtmicon-search"></i>
+                            <div class="position-absolute top-0 end-0 p-1 align-items-center text-center justify-content-center rounded-pill bg-black-1" style="width: 36px; height: 36px; margin-top: -15px; margin-right: -15px;">
+                                <h6 class="accent-primary m-0" data-i18n="1">1.</h6>
+                            </div>
+                        </div>
+                        <div class="d-flex flex-column text-center">
+                            <h4 data-i18n="explore_properties">Izpētiet īpašumus</h4>
+                            <p class="accent-color-4" style="max-width: 300px;" data-i18n="browse_a_wide_selection_of_properties_to_find_the_perfect_home">Pārlūkot plašu īpašību izvēli 
+Atrodiet perfektu māju.</p>
+                        </div>
+                    </div>
+                    <div class="d-flex flex-column gap-5 align-items-center">
+                        <div class="icon-box position-relative">
+                            <i class="rtmicon rtmicon-client-happy"></i>
+                            <div class="position-absolute top-0 end-0 p-1 align-items-center text-center justify-content-center rounded-pill bg-black-1" style="width: 36px; height: 36px; margin-top: -15px; margin-right: -15px;">
+                                <h6 class="accent-primary m-0" data-i18n="2">2.</h6>
+                            </div>
+                        </div>
+                        <div class="d-flex flex-column text-center">
+                            <h4 data-i18n="connect_with_experts">Sazinieties ar ekspertiem</h4>
+                            <p class="accent-color-4" style="max-width: 300px;" data-i18n="get_professional_guidance_from_real_estate_experts_to_make_informed">Saņemiet profesionālu vadību no reālas 
+Īpašuma eksperti, lai informētu.</p>
+                        </div>
+                    </div>
+                    <div class="d-flex flex-column gap-5 align-items-center">
+                        <div class="icon-box position-relative">
+                            <i class="rtmicon rtmicon-envelope-dollar"></i>
+                            <div class="position-absolute top-0 end-0 p-1 align-items-center text-center justify-content-center rounded-pill bg-black-1" style="width: 36px; height: 36px; margin-top: -15px; margin-right: -15px;">
+                                <h6 class="accent-primary m-0" data-i18n="3">3.</h6>
+                            </div>
+                        </div>
+                        <div class="d-flex flex-column text-center">
+                            <h4 data-i18n="seal_the_deal">Aizzīmogot darījumu</h4>
+                                <p class="accent-color-4" style="max-width: 300px;" data-i18n="navigate_negotiations_and_finalize_transactions_smoothly">Orientēties sarunās un pabeigt 
+darījumi vienmērīgi</p>
+                        </div>
+                    </div>
+                </div>
+                <h4 class="text-center text-accent fst-italic  scrollanimation animated fadeInDown adr-7" data-i18n="explore_properties_connect_with_experts_and_seal_the_deal_is_a_streamlined_process_that_takes_you_from_browsing_a_variety_of_properties_to_receiving_professional_advice">Izpētīt 
+Īpašības, sazinieties ar ekspertiem un aizzīmogo 
+Darījums ir racionalizēts process, kas jūs aizved 
+No dažādu īpašumu pārlūkošanas līdz profesionālu padomu saņemšanai</h4>
+            </div>
+        </div>
+
+        <!-- Section Our Service -->
+        <div class="section">
+            <div class="r-container d-flex flex-column gap-5">
+                <div class="row row-cols-xl-2 row-cols-1 align-items-end">
+                    <div class="col mb-3 scrollanimation animated fadeInLeft adr-7">
+                        <h3 data-i18n="real_estate_services_customized_for_you">Jums pielāgoti nekustamā īpašuma pakalpojumi</h3>
+                    </div>
+                    <div class="col mb-3 scrollanimation animated fadeInDown adr-7">
+                        <div class="d-flex flex-column gap-2 align-items-end">
+                            <p style="max-width: 400px;" data-i18n="personalized_solutions_to_help_you_buy_sell_or_invest_in_real_estate_with_ease">
+                                Personalizēti risinājumi, kas palīdzēs jums viegli iegādāties, pārdot vai ieguldīt nekustamajā īpašumā.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="row row-cols-xl-3 row-cols-1">
+                    <div class="col mb-3">
+                        <div class="card card-service">
+                            <div class="d-flex flex-row gap-3 align-items-center">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="CurrentColor" width="66" height="66" data-name="Layer 3" viewBox="0 0 500 500">
+                                    <path d="M59.44,175.81c-9.2,44,3.06,91.63,37.15,125.72,36.95,36.96,90.47,49.44,140.29,33.09l13.71-.69,8.62,7.78,2.56,33.67c.38,4.99,2.67,9.64,6.36,13l22.19,20.18c3.97,3.61,9.26,5.55,14.59,5.05l31.56-2.28,9.22,8.11,1.61,32.64c.26,5.19,2.56,10.06,6.41,13.56l21.32,19.31c3.67,3.32,8.38,5.06,13.15,5.06,2.42,0,4.86-.45,7.18-1.36l59.93-23.62c5.73-2.26,10.05-7.07,11.69-12.98l17.28-62.24c1.99-7.15-.24-14.82-5.76-19.79l-150.65-135.72c10.47-46.08-2.96-93.95-36.51-127.49-37.34-37.34-90.8-48.08-138.05-33.5-12.65-22.13-29.52-40.46-47.84-51.59-21.95-13.33-44.65-15.38-62.29-5.6C9.43,34.79,5.49,90.02,34.17,141.85c7.29,13.16,15.95,24.44,25.27,33.96ZM263.64,134.49c26.12,26.12,35.12,64.52,23.5,100.19-2.4,7.36-.24,15.44,5.51,20.62l150.63,135.69-11.43,41.15-39.53,15.57-6.29-5.69-1.62-32.8c-.26-5.28-2.65-10.24-6.62-13.74l-21.6-19.02c-3.95-3.47-9.23-5.28-14.36-4.83l-31.37,2.27-10.22-9.28-2.56-33.72c-.38-5.01-2.69-9.69-6.43-13.06l-20.46-18.43c-3.85-3.47-8.63-5.14-14.08-5.01l-24.52,1.21c-1.89.09-3.75.46-5.53,1.08-36.26,12.79-75.49,3.99-102.37-22.88-19.92-19.92-29.28-46.32-28.54-72.48,8.7,3.6,17.41,5.67,25.77,5.67,8.48-.01,16.6-1.95,24-6.05,9.46-5.24,12.89-17.17,7.65-26.63-5.23-9.46-17.17-12.87-26.63-7.65-4.6,2.55-12.53,1.07-21.54-4.04,4.72-10.15,10.92-19.79,19.29-28.16,38.4-38.4,100.93-38.43,139.35,0ZM62.14,50.38c4.95-2.7,13.53-.93,22.97,4.81,11.76,7.14,23.27,19.67,32.33,34.57-7.35,4.92-14.37,10.54-20.86,17.03-8.43,8.43-15.06,17.9-20.85,27.73-2.51-3.6-4.96-7.45-7.28-11.65-19.65-35.5-16.86-66.65-6.31-72.49Z" stroke-width="0"></path>
+                                </svg>
+                                <h4 data-i18n="property_buying_assistance">Īpašuma pirkšanas palīdzība</h4>
+                            </div>
+                            <p data-i18n="helping_you_sell_your_property_quickly_and_at_the_best_price_with_expert_marketing_negotiation_and_closing_support">Palīdzot jums ātri pārdot savu īpašumu un par labāko cenu ar ekspertu mārketingu, 
+Sarunas un atbalsts.</p>
+                            <a href="property_details.html" class="d-flex flex-row rounded-pill gap-2 align-items-center read-more">
+                                <span data-i18n="learn_more">Uzziniet vairāk</span>
+                                <i class="rtmicon rtmicon-arrow-up-right" style="font-weight: 600;"></i>
+                            </a>
+                        </div>
+                    </div>
+                    <div class="col mb-3">
+                        <div class="card card-service">
+                            <div class="d-flex flex-row gap-3 align-items-center">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="CurrentColor" width="66" height="66" data-name="Layer 3" viewBox="0 0 500 500">
+                                    <path d="M452.63,15.91c-17.07-9.46-39.06-7.51-60.32,5.42-18.21,11.06-35.01,29.38-47.35,51.58l-52.4-17.91c-24.95-8.6-53.06-2.04-71.68,16.62L40.48,252.02c-13.14,13.14-20.38,30.6-20.38,49.19s7.24,36.04,20.38,49.18l119.23,119.23c13.14,13.14,30.6,20.38,49.18,20.38s36.05-7.24,49.19-20.38l180.78-180.78c18.59-18.59,25.1-45.66,16.97-70.66l-16.35-50.35c8.01-8.65,15.48-18.65,21.85-30.15,27.78-50.19,23.96-103.68-8.71-121.77ZM412.04,262.02l-180.78,180.78c-11.94,11.97-32.75,11.97-44.72,0l-119.23-119.23c-12.33-12.33-12.33-32.39,0-44.72L247.71,98.45c6.06-6.05,14.04-9.29,22.26-9.29,3.45,0,6.93.57,10.32,1.73l91.16,31.17c9.36,3.2,16.78,10.72,19.83,20.14l4.5,13.86c-10.02,6.51-18.94,8.42-23.89,5.67-9.15-5.05-20.71-1.75-25.79,7.41-5.08,9.16-1.75,20.71,7.41,25.79,7.16,3.96,15.03,5.85,23.24,5.85,10,0,20.5-2.99,30.87-8.23l12.12,37.34c3.69,11.36.74,23.66-7.71,32.11ZM428.14,119.31c-1.09,1.97-2.28,3.63-3.42,5.46-7.71-17.92-22.42-32.25-41.02-38.61l-1.91-.65c8.61-13.65,19.29-25.11,30.22-31.74,9.16-5.56,17.49-7.27,22.24-4.66,10.21,5.66,12.92,35.82-6.11,70.2Z" stroke-width="0"></path>
+                                    <path d="M311.73,225.2l8.86-8.86c7.41-7.41,7.41-19.41,0-26.82s-19.41-7.41-26.82,0l-8.96,8.96c-18.25-17.14-46.99-16.91-64.82.92l-2.61,2.61c-18.18,18.18-18.18,47.77,0,65.95l24.77,24.77c3.38,3.4,3.38,8.9,0,12.3l-2.61,2.61c-3.38,3.38-8.92,3.38-12.3,0l-43.68-43.68c-7.41-7.41-19.41-7.41-26.82,0s-7.41,19.41,0,26.82l17.88,17.88-7.32,7.32c-7.41,7.41-7.41,19.41,0,26.82,3.71,3.71,8.56,5.56,13.41,5.56s9.71-1.85,13.41-5.56l7.43-7.43c8.95,8.4,20.37,12.71,31.85,12.71s23.89-4.54,32.98-13.63l2.61-2.61c18.18-18.18,18.18-47.77,0-65.95l-24.77-24.77c-3.38-3.4-3.38-8.9,0-12.3l2.61-2.61c3.38-3.38,8.92-3.38,12.3,0l43.68,43.68c7.41,7.41,19.41,7.41,26.82,0,7.41-7.41,7.41-19.41,0-26.82l-17.88-17.88Z" stroke-width="0"></path>
+                                </svg>
+                                <h4 data-i18n="property_selling_assistance">Īpašuma pārdošanas palīdzība</h4>
+                            </div>
+                            <p data-i18n="expert_guidance_to_help_you_find_evaluate_and_purchase_the_perfect_property_with_ease_and_confidence">Ekspertu norādījumi, kas palīdzēs jums viegli atrast, novērtēt un iegādāties perfektu īpašumu 
+un pārliecība.</p>
+                            <a href="property_details.html" class="d-flex flex-row rounded-pill gap-2 align-items-center read-more">
+                                <span data-i18n="learn_more">Uzziniet vairāk</span>
+                                <i class="rtmicon rtmicon-arrow-up-right" style="font-weight: 600;"></i>
+                            </a>
+                        </div>
+                    </div>
+                    <div class="col mb-3">
+                        <div class="card card-service">
+                            <div class="d-flex flex-row gap-3 align-items-center">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="CurrentColor" width="66" height="66" data-name="Layer 3" viewBox="0 0 500 500">
+                                    <path d="M451.94,231.45l-143.79-143.79c1.56-5.38,2.67-10.96,2.67-16.84,0-33.53-27.28-60.81-60.81-60.81s-60.81,27.28-60.81,60.81c0,5.95,1.13,11.59,2.73,17.03L48.07,231.44c-21.66,4.2-38.07,23.26-38.07,46.12v165.41c0,25.93,21.09,47.03,47.03,47.03h385.95c25.93,0,47.03-21.09,47.03-47.03v-165.41c0-22.86-16.41-41.92-38.06-46.12ZM250,48.92c12.07,0,21.89,9.82,21.89,21.89s-9.82,21.89-21.89,21.89-21.89-9.82-21.89-21.89,9.82-21.89,21.89-21.89ZM214.67,120.11c9.98,7.17,22.12,11.51,35.33,11.51s25.45-4.39,35.46-11.62l110.54,110.54H104.06l110.62-110.43ZM451.08,442.97c0,4.47-3.64,8.11-8.11,8.11H57.03c-4.47,0-8.11-3.64-8.11-8.11v-165.41c0-4.47,3.64-8.11,8.11-8.11h385.95c4.47,0,8.11,3.64,8.11,8.11v165.41Z" stroke-width="0"></path>
+                                    <path d="M148.8,381.64c-2.5-4.09-5.36-7.99-8.53-11.59-1.23-1.39-2.48-2.66-3.76-3.81,4.9-1.91,8.88-4.45,11.88-7.6,4.59-4.88,6.9-11.35,6.9-19.27,0-3.84-.67-7.54-2-10.98-1.36-3.51-3.36-6.63-5.97-9.3-2.61-2.64-5.62-4.7-8.87-6.06-2.74-1.25-5.84-2.1-9.27-2.52-3.19-.38-6.89-.56-11.3-.56h-30.58c-5.09,0-8.98,1.29-11.58,3.88-2.55,2.56-3.84,6.45-3.84,11.54v71.45c0,4.7,1.14,8.42,3.38,11.07,4.64,5.45,14.39,5.79,19.59.25,2.39-2.6,3.61-6.41,3.61-11.33v-25.95h2.7c2.83,0,5.13.35,6.84,1.05,1.63.66,3.33,1.98,5.04,3.9,1.99,2.26,4.28,5.59,6.83,9.95l7.55,12.54c1.82,3.04,3.26,5.35,4.32,6.9,1.29,1.89,2.86,3.48,4.73,4.8,2.09,1.43,4.62,2.15,7.51,2.15,2.43,0,4.62-.51,6.42-1.46,1.95-.98,3.55-2.38,4.79-4.26,1.17-1.86,1.75-3.79,1.75-5.71,0-1.22-.27-3.22-2.31-7.98-1.36-3.26-3.26-6.89-5.84-11.12ZM126.95,345.79c-1.08,1.25-2.79,2.18-5.07,2.76-2.76.7-6.27,1.05-10.45,1.05h-12.96v-17.75h13.47c8.03,0,10.71.76,11.48,1.09,1.62.68,2.85,1.66,3.71,2.94.89,1.36,1.32,2.89,1.32,4.69,0,2.32-.51,4.07-1.49,5.22Z" stroke-width="0"></path>
+                                    <path d="M231.86,387.86h-39.95v-18.64h35.13c3.91,0,6.99-1.03,9.16-3.08,2.17-2.09,3.27-4.76,3.27-7.97s-1.18-5.97-3.37-7.94c-2.13-1.98-5.18-2.98-9.06-2.98h-35.13v-15.03h38.48c3.95,0,7.08-1,9.34-3.03,2.24-2.08,3.42-4.9,3.42-8.15s-1.19-6.04-3.45-8.1c-2.22-2.03-5.27-3.02-9.31-3.02h-49.66c-3.23,0-5.89.49-8.2,1.52-2.55,1.18-4.51,3.14-5.62,5.61-1.06,2.22-1.6,5-1.6,8.29v69.81c0,5.08,1.28,8.96,3.81,11.54,2.55,2.57,6.46,3.88,11.6,3.88h51.13c3.94,0,7.07-1.03,9.29-3.07,2.31-2.09,3.52-4.94,3.52-8.23s-1.22-6.27-3.52-8.36c-2.22-2.04-5.35-3.07-9.29-3.07Z" stroke-width="0"></path>
+                                    <path d="M315.75,312.43c-2.14,2.52-3.23,6.08-3.23,10.59v42.29l-29.01-43.91-2.93-4.57c-1.08-1.68-2.18-3.13-3.27-4.23-1.24-1.29-2.72-2.32-4.36-3.05-3.95-1.8-9.76-1.57-14.05,1.24-2.51,1.6-4.36,3.75-5.55,6.55-.85,2.22-1.27,5.09-1.27,8.54v71.64c0,4.43,1.13,7.98,3.38,10.6,4.67,5.26,13.75,5.36,18.53.06,2.31-2.53,3.47-6.12,3.47-10.67v-41.33l28.19,43.2c1.04,1.52,2.07,2.99,3.09,4.41,1.22,1.7,2.5,3.13,3.85,4.33,1.53,1.38,3.26,2.43,5.09,3.09,1.76.63,3.74.95,5.88.95,4.22,0,14.02-1.57,14.02-16.11v-73.04c0-4.55-1.11-8.13-3.29-10.6-4.54-5.27-13.95-5.38-18.56.01Z" stroke-width="0"></path>
+                                    <path d="M424.46,313.12c-2.31-2.1-5.62-3.17-9.87-3.17h-59.8c-4,0-7.22,1.01-9.6,3.03-2.48,2.13-3.79,5.12-3.79,8.65s1.25,6.35,3.62,8.49c2.28,2.08,5.57,3.13,9.77,3.13h16.63v63.57c0,4.83,1.23,8.6,3.66,11.25,2.47,2.69,5.82,4.1,9.68,4.1s7.07-1.37,9.58-4.08c2.39-2.61,3.61-6.4,3.61-11.28v-63.57h16.63c4.17,0,7.47-1.04,9.78-3.08,2.45-2.14,3.74-5.09,3.74-8.54s-1.27-6.37-3.65-8.51Z" stroke-width="0"></path>
+                                </svg>
+                                <h4 data-i18n="property_rental_services">Īpašuma nomas pakalpojumi</h4>
+                            </div>
+                            <p data-i18n="assisting_landlords_and_tenants_in_finding_the_perfect_rental_match_with_seamless_leasing_and_management_solutions">Palīdzība namīpašniekiem un īrniekiem perfektas nomas mača atrašanā ar bezšuvju nomu 
+un vadības risinājumi.</p>
+                            <a href="property_details.html" class="d-flex flex-row rounded-pill gap-2 align-items-center read-more">
+                                <span data-i18n="learn_more">Uzziniet vairāk</span>
+                                <i class="rtmicon rtmicon-arrow-up-right" style="font-weight: 600;"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <div class="row row-cols-xl-2 row-cols-1 align-items-center p-5 rounded-2 bg-black-1">
+                    <div class="col col-xl-8 mb-3">
+                        <h4 class="accent-primary" data-i18n="uncover_a_wide_range_of_ways_we_can_assist_you_browse_through_all_our_services_now">Atklājiet plašu veidu, kā mēs varam jums palīdzēt. 
+Pārlūkojiet visus mūsu pakalpojumus tagad!</h4>
+                    </div>
+                    <div class="col col-xl-4 mb-3">
+                        <div class="w-max-content" style="justify-self: end;">
+                            <a href="service.html" class="btn btn-accent accent d-flex flex-row gap-2 justify-content-center">
+                                <span data-i18n="more_service">Vairāk servisa</span>
+                                <i class="rtmicon rtmicon-arrow-up-right fw-bold"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    </main>
+
+    <footer>
+        <div class="section position-relative bg-black-1" style="height: 90vh;">
+            <div class="row row-cols-xl-2 row-cols-1 h-100">
+                <div class="col col-xl-8 mb-3">
+                    <div class="d-flex flex-column gap-3 justify-content-between h-100">
+                        <div class="d-flex flex-column accent-primary">
+                            <p class="gray" data-i18n="get_contact">Sazināties</p>
+                            <h1 class="fw-normal" data-i18n="infovandoreheritagelv">info@vandoreheritage.lv</h1>
+                        </div>
+                        <img src="../image/logo-footer.png?v=2025" alt="Vandore Heritage" class="img-fluid" width="938">
+                    </div>
+                </div>
+                <div class="col col-xl-4 mb-3">
+                    <div class="d-flex flex-column gap-5 justify-content-between accent-primary h-100">
+                        <div class="d-flex flex-row gap-5">
+                            <ul class="list-unstyled d-flex flex-column gap-3 accent-color">
+                                <li>
+                                    <a href="index.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="home">
+                                        Mājas
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="about.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="about">
+                                        Pret
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="properties.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="properties">
+                                        Īpašības
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="rentals.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="rentals">
+                                        Īre
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="service.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="service">
+                                        Sakārtošana
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="contact.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="contact_us">
+                                        Sazinieties ar mums
+                                    </a>
+                                </li>
+                            </ul>
+                            <div class="d-flex flex-column gap-3">
+                                <a href="https://www.google.com/maps/place/Skanstes+iela+29A,+Vidzemes+priekšpilsēta,+Rīga,+LV-1013,+Latvia" class="link" target="_blank" data-i18n="skanstes_iela_29a91_rga_latvia">
+                                    Skanstes Iela 29A - 91, Rīga, Latvija
+                                </a>
+                                <a href="tel:+37129713030" class="link" data-i18n="371_29_71_3030">
+                                    +371 29 71 3030
+                                </a>
+                            </div>
+                        </div>
+                        <div class="d-flex flex-row gap-3">
+                            <div class="border-end pe-3 border-gray">
+                                <a href="" class="link d-flex flex-row gap-3 align-items-center" data-i18n="terms_conditions">
+                                    Noteikumi un nosacījumi
+                                </a>
+                            </div>
+                            <div>
+                                <a href="" class="link d-flex flex-row gap-3 align-items-center" data-i18n="privacy_notice">
+                                    Paziņojums par privātumu
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+
+    <!-- Back to top button -->
+    <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="rtmicon rtmicon-arrow-up"></i></a>
+
+    <!-- Scripts -->
+    <script src="../js/vendor/jquery.min.js"></script>
+    <script src="../js/vendor/bootstrap.bundle.min.js"></script>
+    <script src="../js/vendor/swiper-bundle.min.js"></script>
+    <script src="../js/script.js"></script>
+    <script src="../js/swiper-script.js"></script>
+    <script src="../js/submit-form.js"></script>
+    <script src="../js/vendor/isotope.pkgd.min.js"></script>
+    <script src="../js/video_embedded.js"></script>
+    <script src="../js/vendor/fslightbox.js"></script>
+    <script src="../js/custom.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.0/oyethemes_onscroll_animation.js"></script>
+
+
+
+</body></html>

--- a/content/index.njk
+++ b/content/index.njk
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ (pages.index.title) or 'Home' }}</title>
+    <link rel="stylesheet" href="/css/style.css">
+  </head>
+  <body>
+    <header>
+      <h1>{{ (pages.index.heroHeading) or 'Welcome' }}</h1>
+      <p>{{ (pages.index.heroSubheading) or '' }}</p>
+      <nav>
+        <a href="/index.html">Home</a>
+        <a href="/properties.html">Properties</a>
+        <a href="/contact.html">Contact</a>
+      </nav>
+    </header>
+
+    <main>
+      {% if pages.index.sections %}
+        {% for s in pages.index.sections %}
+          <section>
+            <h2>{{ s.heading }}</h2>
+            <p>{{ s.text }}</p>
+          </section>
+        {% endfor %}
+      {% endif %}
+
+      <section>
+        <h2>Sample Property</h2>
+        <ul>
+          {% for p in collections.property %}
+            <li>
+              <a href="/properties/{{ p.fileSlug }}.html">{{ p.data.title }}</a>
+              <span>{{ p.data.price }}</span>
+            </li>
+          {% endfor %}
+        </ul>
+      </section>
+    </main>
+
+    <footer>
+      <small>&copy; Vandore</small>
+    </footer>
+  </body>
+  </html>
+

--- a/content/pages/index.json
+++ b/content/pages/index.json
@@ -1,0 +1,9 @@
+{
+  "title": "Home",
+  "heroHeading": "Welcome to Vandore",
+  "heroSubheading": "Find properties to buy or rent.",
+  "sections": [
+    { "heading": "Featured", "text": "A few featured listings and news." }
+  ]
+}
+

--- a/content/properties/sample.json
+++ b/content/properties/sample.json
@@ -1,0 +1,13 @@
+{
+  "title": "Sample Apartment",
+  "price": "€120,000",
+  "address": "Example St 10, Riga",
+  "description": "Cozy 2-bedroom apartment in the city center.",
+  "image": "/image/property/property_1.jpg",
+  "url": "/properties/sample.html",
+  "bedrooms": 2,
+  "bathrooms": 1,
+  "area": 65,
+  "floors": 5
+}
+

--- a/content/property-detail.njk
+++ b/content/property-detail.njk
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Property Detail</title>
+    <link rel="stylesheet" href="/css/style.css">
+  </head>
+  <body>
+    <header>
+      <nav>
+        <a href="/index.html">Home</a>
+        <a href="/properties.html">Properties</a>
+      </nav>
+    </header>
+
+    <main>
+      {#
+        Render the first property from the collection whose slug matches the output file.
+        If not available (e.g. in VE dev), render any available property as a fallback.
+      #}
+      {% set current = null %}
+      {% for p in collections.property %}
+        {% if current == null %}
+          {% set current = p %}
+        {% endif %}
+      {% endfor %}
+
+      {% if current %}
+        <article>
+          <h1>{{ current.data.title or 'Property' }}</h1>
+          <p><strong>Price:</strong> {{ current.data.price or '' }}</p>
+          <p><strong>Address:</strong> {{ current.data.address or '' }}</p>
+          <p>{{ current.data.description or '' }}</p>
+          {% if current.data.image %}
+            <img alt="Property image" src="{{ current.data.image }}" style="max-width: 600px; width: 100%; height: auto;"/>
+          {% endif %}
+        </article>
+      {% else %}
+        <p>No property data available yet.</p>
+      {% endif %}
+    </main>
+  </body>
+  </html>
+


### PR DESCRIPTION
- Created index.njk for the homepage with navigation and sections.
- Added index.json for homepage content including title, hero heading, and sections.
- Introduced sample.json for a property listing with details like title, price, and description.
- Developed property-detail.njk to display individual property details dynamically.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Set up the initial Eleventy site with a data-driven homepage and a dynamic property detail page. Keeps existing static pages deploying while introducing a properties collection for future listings.

- **New Features**
  - Eleventy: passthrough copy from pages/ to site root; loads content/pages/*.json into a global pages map; registers a properties collection from content/properties.
  - Homepage: content/index.njk driven by content/pages/index.json (title, hero, sections) with simple nav.
  - Property detail: content/property-detail.njk renders a property from the collection; example output at /property-detail/.
  - Sample data: content/properties/sample.json (title, price, address, description, image, metadata).

- **Migration**
  - Add/edit page content via JSON in content/pages (e.g., index.json).
  - Add new listings by dropping JSON files into content/properties.

<!-- End of auto-generated description by cubic. -->

