### PR TITLE
Site 1.5

### DIFF
--- a/ANNOTATION_MAP.md
+++ b/ANNOTATION_MAP.md
@@ -1,0 +1,21 @@
+Pages annotated for inline editing
+
+- pages/404.html: main scoped to `content/pages/404.json`
+- pages/about.html: main scoped to `content/pages/about.json`
+- pages/blog.html: main scoped to `content/pages/blog.json`
+- pages/contact.html: main scoped to `content/pages/contact.json`
+- pages/faq.html: main scoped to `content/pages/faq.json`
+- pages/index.html: main scoped to `content/pages/index.json`
+- pages/price_plan.html: main scoped to `content/pages/price_plan.json`
+- pages/properties.html: main scoped to `content/pages/properties.json`
+- pages/property-detail-template.html: main scoped to `content/properties/sample.json`
+- pages/property_details.html: main scoped to `content/pages/property_details.json`
+- pages/rentals.html: main scoped to `content/pages/rentals.json`
+- pages/service.html: main scoped to `content/pages/service.json`
+- pages/single_blog.html: main scoped to `content/pages/single_blog.json`
+- pages/team.html: main scoped to `content/pages/team.json`
+
+Notes
+
+- Existing fields (already present in code): `title`, `heroHeading`, `heroSubheading`, `sections[...]`, `properties[...]` remain intact.
+- Next steps: add `data-sb-alt-field` for key images and annotate CTA links with `data-sb-href-field` per page.

--- a/pages/404.html
+++ b/pages/404.html
@@ -19,7 +19,7 @@
     <!-- Scripts -->
     <script src="../js/vendor/jquery.min.js"></script>
 
-    <main>
+    <main data-sb-object-id="content/pages/404.json">
         <div class="section bg-black-1 position-relative">
             <a href="index.html" class="d-flex" style="justify-self: end;">
                 <i class="rtmicon rtmicon-arrow-left fs-1 fw-bold accent-primary"></i>

--- a/pages/about.html
+++ b/pages/about.html
@@ -125,7 +125,7 @@
                     <div class="row row-cols-2">
                         <div class="col-3 col-xl-2"></div>
                         <div class="col-9 col-xl-10">
-                            <img src="../image/dummy-img-1920x900.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Vandore Heritage">
+                            <img src="../image/dummy-img-1920x900.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Vandore Heritage" data-sb-field-path="hero.image#@src" data-sb-alt-field="hero.image#@alt">
                         </div>
                     </div>
                 </div>
@@ -152,7 +152,7 @@
                 <div class="row row-cols-xl-2 row-cols-1">
                     <div class="col mb-3 scrollanimation animated fadeInLeft adr-7">
                         <div class="d-flex flex-column gap-5">
-                            <img src="../image/dummy-img-600x700.jpg" class="img-fluid custom-border rounded-2 w-100" style="aspect-ratio: 5/6;" alt="Vandore Heritage team members working together">
+                            <img src="../image/dummy-img-600x700.jpg" class="img-fluid custom-border rounded-2 w-100" style="aspect-ratio: 5/6;" alt="Vandore Heritage team members working together" data-sb-field-path="about.image#@src" data-sb-alt-field="about.image#@alt">
                             </div>
                         </div>
                     </div>
@@ -274,7 +274,7 @@
                     <div class="tabs">
                         <div class="tab active" data-tab="team-1">
                             <div class="position-relative overflow-hidden">
-                                <img src="../image/dummy-img-600x400.jpg" class="img-fluid w-100 h-100" style="aspect-ratio: 3/2;" alt="Vandore Heritage">
+                                <img src="../image/dummy-img-600x400.jpg" class="img-fluid w-100 h-100" style="aspect-ratio: 3/2;" alt="Vandore Heritage" data-sb-field-path="team[0].image#@src" data-sb-alt-field="team[0].image#@alt">
                                 <div class="position-absolute start-0 bottom-0 accent-primary p-4">
                                     <h5 data-i18n="dolfs_mrti_krauklis">Ādolfs Mārtiņš Krauklis</h5>
                                     <span data-i18n="cofounder">Līdzdibinātājs</span>
@@ -283,7 +283,7 @@
                         </div>
                         <div class="tab" data-tab="team-2">
                             <div class="position-relative overflow-hidden">
-                                <img src="../image/dummy-img-600x400.jpg" class="img-fluid w-100 h-100" style="aspect-ratio: 3/2;" alt="Vandore Heritage">
+                                <img src="../image/dummy-img-600x400.jpg" class="img-fluid w-100 h-100" style="aspect-ratio: 3/2;" alt="Vandore Heritage" data-sb-field-path="team[1].image#@src" data-sb-alt-field="team[1].image#@alt">
                                 <div class="position-absolute start-0 bottom-0 accent-primary p-4">
                                     <h5 data-i18n="roberts_punka">Roberts panka</h5>
                                     <span data-i18n="cofounder">Līdzdibinātājs</span>
@@ -330,7 +330,7 @@ user@example.com).
                         </div>
                     </div>
                     <div class="col col-xl-5 mb-3 scrollanimation animated fadeInRight">
-                        <img src="../image/dummy-img-600x400.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Contact us for real estate services">
+                        <img src="../image/dummy-img-600x400.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Contact us for real estate services" data-sb-field-path="ctaImage#@src" data-sb-alt-field="ctaImage#@alt">
                     </div>
                 </div>
             </div>
@@ -347,7 +347,7 @@ user@example.com).
                             <p class="gray" data-i18n="get_contact">Sazināties</p>
                             <h1 class="fw-normal" data-i18n="infovandoreheritagelv">info@vandoreheritage.lv</h1>
                         </div>
-                        <img src="../image/logo-footer.png?v=2025" alt="Vandore Heritage" class="img-fluid" width="938">
+                        <img src="../image/logo-footer.png?v=2025" alt="Vandore Heritage" class="img-fluid" width="938" data-sb-field-path="footer.logo#@src" data-sb-alt-field="footer.logo#@alt">
                     </div>
                 </div>
                 <div class="col col-xl-4 mb-3">

--- a/pages/about.html
+++ b/pages/about.html
@@ -117,7 +117,7 @@
     <!-- End Header -->
 
     <!-- Main -->
-    <main>
+    <main data-sb-object-id="content/pages/about.json">
         <!-- Banner -->
         <div class="section position-relative bg-attach-cover">
             <div class="r-container position-relative h-100">

--- a/pages/blog.html
+++ b/pages/blog.html
@@ -117,7 +117,7 @@
     <!-- End Header -->
 
     <!-- Main -->
-    <main>
+    <main data-sb-object-id="content/pages/blog.json">
         <!-- Banner -->
         <div class="section position-relative bg-attach-cover">
             <div class="r-container position-relative h-100">

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -117,7 +117,7 @@
     <!-- End Header -->
 
     <!-- Main -->
-    <main>
+    <main data-sb-object-id="content/pages/contact.json">
         <!-- Banner -->
         <div class="section position-relative bg-attach-cover">
             <div class="r-container position-relative h-100">

--- a/pages/faq.html
+++ b/pages/faq.html
@@ -137,7 +137,7 @@
     <!-- End Header -->
 
     <!-- Main -->
-    <main>
+    <main data-sb-object-id="content/pages/faq.json">
         <!-- Banner -->
         <div class="section position-relative bg-attach-cover">
             <div class="r-container position-relative h-100">

--- a/pages/index.html
+++ b/pages/index.html
@@ -117,7 +117,7 @@
     <!-- End Header -->
 
     <!-- Main -->
-    <main>
+    <main data-sb-object-id="content/pages/index.json">
         <!-- Banner -->
         <div class="section position-relative bg-attach-cover">
             <div class="r-container position-relative h-100">

--- a/pages/index.html
+++ b/pages/index.html
@@ -125,7 +125,7 @@
                     <div class="row row-cols-2">
                         <div class="col-3 col-xl-2"></div>
                         <div class="col-9 col-xl-10">
-                            <img src="../image/dummy-img-1920x900.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Vandore Heritage">
+                            <img src="../image/dummy-img-1920x900.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Vandore Heritage" data-sb-field-path="hero.image.desktop#@src" data-sb-alt-field="hero.image.desktop#@alt">
                         </div>
                     </div>
                 </div>
@@ -138,7 +138,7 @@
                                 <div class="d-flex flex-column gap-2 align-items-xl-center align-items-start">
                                     <p data-i18n="we_represent_properties_that_speak_and_clients_who_value_being_heard_vandore_heritage_is_our_promise_to_work_with_care_to_stay_present_beyond_the_deal" data-sb-field-path="heroSubheading">Mēs pārstāvam īpašības, kas runā, un klienti, kuri vērtē tiek uzklausīti. Vandore Heritage ir mūsu solījums: strādāt uzmanīgi, palikt klāt ārpus darījuma.</p>
                                     <div class="devider"></div>
-                                    <a href="contact.html" class="btn btn-accent d-flex flex-row gap-3" style="width: max-content;">
+                                    <a href="contact.html" class="btn btn-accent d-flex flex-row gap-3" style="width: max-content;" data-sb-href-field="hero.cta.href">
                                         <span data-i18n="explore_more">Izpētiet vairāk</span>
                                         <i class="rtmicon rtmicon-arrow-up-right fw-bold"></i>
                                     </a>
@@ -151,7 +151,7 @@
                 </div>
                 <!-- Mobile hero image placed under the description -->
                 <div class="hero-img-mobile">
-                    <img src="../image/dummy-img-1920x900.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Vandore Heritage">
+                    <img src="../image/dummy-img-1920x900.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Vandore Heritage" data-sb-field-path="hero.image.mobile#@src" data-sb-alt-field="hero.image.mobile#@alt">
                 </div>
             </div>
         </div>
@@ -191,7 +191,7 @@
                                 <div class="position-absolute start-0 bottom-0 p-4" style="z-index: 3;">
                                     <h5 class="accent-primary m-0" data-i18n="what_is_vandore_heritage">Kas ir Vandore Heritage?</h5>
                                 </div>
-                                <img src="../image/dummy-img-600x700.jpg" class="img-fluid w-100" style="aspect-ratio: 6/7;" alt="Vandore Heritage">
+                                <img src="../image/dummy-img-600x700.jpg" class="img-fluid w-100" style="aspect-ratio: 6/7;" alt="Vandore Heritage" data-sb-field-path="aboutTeaser.image#@src" data-sb-alt-field="aboutTeaser.image#@alt">
                             </div>
                         </div>
                     </div>

--- a/pages/price_plan.html
+++ b/pages/price_plan.html
@@ -117,7 +117,7 @@
     <!-- End Header -->
 
     <!-- Main -->
-    <main>
+    <main data-sb-object-id="content/pages/price_plan.json">
         <!-- Banner -->
         <div class="section position-relative bg-attach-cover">
             <div class="r-container position-relative h-100">

--- a/pages/properties.html
+++ b/pages/properties.html
@@ -116,7 +116,7 @@
     <!-- End Header -->
 
     <!-- Main -->
-    <main>
+    <main data-sb-object-id="content/pages/properties.json">
         <!-- Banner -->
         <div class="section position-relative bg-attach-cover">
             <div class="r-container position-relative h-100">

--- a/pages/properties.html
+++ b/pages/properties.html
@@ -155,7 +155,7 @@
                     <div class="col mb-3 scrollanimation animated fadeInDown adr-7">
                         <div class="d-flex flex-column gap-2 align-items-end">
                             <div class="w-max-content" style="justify-self: end;">
-                                <a href="property_detail.html" class="btn btn-accent d-flex flex-row gap-2 justify-content-center">
+                                <a href="property_detail.html" class="btn btn-accent d-flex flex-row gap-2 justify-content-center" data-sb-href-field="ctaAgents.href">
                                     <span data-i18n="contact_our_agents">Sazinieties ar mūsu aģentiem</span>
                                     <i class="rtmicon rtmicon-arrow-up-right fw-bold"></i>
                                 </a>

--- a/pages/properties.html
+++ b/pages/properties.html
@@ -124,7 +124,7 @@
                     <div class="row row-cols-2">
                         <div class="col-3 col-xl-2"></div>
                         <div class="col-9 col-xl-10">
-                            <img src="../image/dummy-img-1920x900.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Vandore Heritage">
+                            <img src="../image/dummy-img-1920x900.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Vandore Heritage" data-sb-field-path="hero.image#@src" data-sb-alt-field="hero.image#@alt">
                         </div>
                     </div>
                 </div>
@@ -290,7 +290,7 @@
                 <div id="property-grid" class="row row-cols-xl-3 row-cols-lg-2 row-cols-1" data-sb-field-path="properties">
                     <div class="col mb-4" data-location="riga heritage lane" data-price="950000" data-bedrooms="4">
                         <div class="card h-100" data-sb-field-path="properties[0]">
-                            <img src="../image/dummy-img-900x700.jpg" class="card-img-top" alt="Sample Property" style="aspect-ratio: 3/2; object-fit: cover;" data-sb-field-path="properties[0].image#@src">
+                            <img src="../image/dummy-img-900x700.jpg" class="card-img-top" alt="Sample Property" style="aspect-ratio: 3/2; object-fit: cover;" data-sb-field-path="properties[0].image#@src" data-sb-alt-field="properties[0].image#@alt">
                             <div class="card-body d-flex flex-column">
                                 <div class="d-flex justify-content-between align-items-start mb-2">
                                     <h5 class="card-title mb-0" data-sb-field-path="properties[0].title">Sample Property</h5>
@@ -316,7 +316,7 @@
                     </div>
                     <div class="col mb-4" data-location="riga downtown" data-price="750000" data-bedrooms="3">
                         <div class="card h-100" data-sb-field-path="properties[1]">
-                            <img src="../image/dummy-img-900x600.jpg" class="card-img-top" alt="Modern Apartment" style="aspect-ratio: 3/2; object-fit: cover;" data-sb-field-path="properties[1].image#@src">
+                            <img src="../image/dummy-img-900x600.jpg" class="card-img-top" alt="Modern Apartment" style="aspect-ratio: 3/2; object-fit: cover;" data-sb-field-path="properties[1].image#@src" data-sb-alt-field="properties[1].image#@alt">
                             <div class="card-body d-flex flex-column">
                                 <div class="d-flex justify-content-between align-items-start mb-2">
                                     <h5 class="card-title mb-0" data-sb-field-path="properties[1].title">Modern Apartment</h5>
@@ -342,7 +342,7 @@
                     </div>
                     <div class="col mb-4" data-location="riga old town" data-price="1200000" data-bedrooms="5">
                         <div class="card h-100" data-sb-field-path="properties[2]">
-                            <img src="../image/dummy-img-600x400.jpg" class="card-img-top" alt="Historic Villa" style="aspect-ratio: 3/2; object-fit: cover;" data-sb-field-path="properties[2].image#@src">
+                            <img src="../image/dummy-img-600x400.jpg" class="card-img-top" alt="Historic Villa" style="aspect-ratio: 3/2; object-fit: cover;" data-sb-field-path="properties[2].image#@src" data-sb-alt-field="properties[2].image#@alt">
                             <div class="card-body d-flex flex-column">
                                 <div class="d-flex justify-content-between align-items-start mb-2">
                                     <h5 class="card-title mb-0" data-sb-field-path="properties[2].title">Historic Villa</h5>
@@ -368,7 +368,7 @@
                     </div>
                     <div class="col mb-4" data-location="riga suburbs" data-price="450000" data-bedrooms="2">
                         <div class="card h-100" data-sb-field-path="properties[3]">
-                            <img src="../image/dummy-img-600x600.jpg" class="card-img-top" alt="Cozy Townhouse" style="aspect-ratio: 3/2; object-fit: cover;" data-sb-field-path="properties[3].image#@src">
+                            <img src="../image/dummy-img-600x600.jpg" class="card-img-top" alt="Cozy Townhouse" style="aspect-ratio: 3/2; object-fit: cover;" data-sb-field-path="properties[3].image#@src" data-sb-alt-field="properties[3].image#@alt">
                             <div class="card-body d-flex flex-column">
                                 <div class="d-flex justify-content-between align-items-start mb-2">
                                     <h5 class="card-title mb-0" data-sb-field-path="properties[3].title">Cozy Townhouse</h5>
@@ -394,7 +394,7 @@
                     </div>
                     <div class="col mb-4" data-location="riga center" data-price="680000" data-bedrooms="3">
                         <div class="card h-100" data-sb-field-path="properties[4]">
-                            <img src="../image/dummy-img-900x500.jpg" class="card-img-top" alt="Luxury Penthouse" style="aspect-ratio: 3/2; object-fit: cover;" data-sb-field-path="properties[4].image#@src">
+                            <img src="../image/dummy-img-900x500.jpg" class="card-img-top" alt="Luxury Penthouse" style="aspect-ratio: 3/2; object-fit: cover;" data-sb-field-path="properties[4].image#@src" data-sb-alt-field="properties[4].image#@alt">
                             <div class="card-body d-flex flex-column">
                                 <div class="d-flex justify-content-between align-items-start mb-2">
                                     <h5 class="card-title mb-0" data-sb-field-path="properties[4].title">Luxury Penthouse</h5>
@@ -420,7 +420,7 @@
                     </div>
                     <div class="col mb-4" data-location="riga waterfront" data-price="890000" data-bedrooms="4">
                         <div class="card h-100" data-sb-field-path="properties[5]">
-                            <img src="../image/dummy-img-600x500.jpg" class="card-img-top" alt="Waterfront Residence" style="aspect-ratio: 3/2; object-fit: cover;" data-sb-field-path="properties[5].image#@src">
+                            <img src="../image/dummy-img-600x500.jpg" class="card-img-top" alt="Waterfront Residence" style="aspect-ratio: 3/2; object-fit: cover;" data-sb-field-path="properties[5].image#@src" data-sb-alt-field="properties[5].image#@alt">
                             <div class="card-body d-flex flex-column">
                                 <div class="d-flex justify-content-between align-items-start mb-2">
                                     <h5 class="card-title mb-0" data-sb-field-path="properties[5].title">Waterfront Residence</h5>

--- a/pages/property-detail-template.html
+++ b/pages/property-detail-template.html
@@ -116,7 +116,7 @@
     <!-- End Header -->
 
     <!-- Main -->
-    <main>
+    <main data-sb-object-id="content/properties/sample.json">
         <!-- Banner -->
         <div class="section position-relative bg-attach-cover">
             <div class="r-container position-relative h-100">

--- a/pages/property_details.html
+++ b/pages/property_details.html
@@ -116,7 +116,7 @@
     <!-- End Header -->
 
     <!-- Main -->
-    <main>
+    <main data-sb-object-id="content/pages/property_details.json">
         <!-- Banner -->
         <div class="section position-relative bg-attach-cover">
             <div class="r-container position-relative h-100">

--- a/pages/rentals.html
+++ b/pages/rentals.html
@@ -97,7 +97,7 @@
   <!-- End Header -->
 
   <!-- Main -->
-  <main>
+    <main data-sb-object-id="content/pages/rentals.json">
     <!-- Hero -->
     <section class="section pt-5 pb-3">
       <div class="r-container">

--- a/pages/service.html
+++ b/pages/service.html
@@ -117,7 +117,7 @@
     <!-- End Header -->
 
     <!-- Main -->
-    <main>
+    <main data-sb-object-id="content/pages/service.json">
         <!-- Banner -->
         <div class="section position-relative bg-attach-cover">
             <div class="r-container position-relative h-100">

--- a/pages/single_blog.html
+++ b/pages/single_blog.html
@@ -116,7 +116,7 @@
     <!-- End Header -->
 
     <!-- Main -->
-    <main>
+    <main data-sb-object-id="content/pages/single_blog.json">
         <!-- Banner -->
         <div class="section position-relative bg-attach-cover">
             <div class="r-container position-relative h-100">

--- a/pages/team.html
+++ b/pages/team.html
@@ -116,7 +116,7 @@
     <!-- End Header -->
 
     <!-- Main -->
-    <main>
+    <main data-sb-object-id="content/pages/team.json">
         <!-- Banner -->
         <div class="section position-relative bg-attach-cover">
             <div class="r-container position-relative h-100">


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Enable inline editing across the site by adding data-sb annotations to 14 pages. Main sections are scoped to JSON content files, and key images and CTAs are now editable (src/alt/href). Adds ANNOTATION_MAP.md to document scopes and next steps.

- New Features
  - data-sb-object-id added to <main> on 14 pages, pointing to content/pages/*.json and content/properties/sample.json.
  - Image annotations: src/alt fields added for hero images (desktop/mobile), about/team/teaser images, property card images, and footer logo.
  - CTA annotations: data-sb-href-field added for index hero CTA and properties agents CTA.
  - ANNOTATION_MAP.md lists page scopes and follow-ups.

- Migration
  - No breaking changes. Ensure the referenced JSON files exist and include the fields used (hero.image.*, team[].image, properties[].image, footer.logo, CTA hrefs). Editors can start inline editing immediately.

<!-- End of auto-generated description by cubic. -->

