### PR TITLE
Site 1.5

### DIFF
--- a/ANNOTATION_MAP.md
+++ b/ANNOTATION_MAP.md
@@ -18,6 +18,8 @@ Pages annotated for inline editing
 Notes
 
 - Existing fields (already present in code): `title`, `heroHeading`, `heroSubheading`, `sections[...]`, `properties[...]` remain intact.
-- SEO: added `seo.description`, `seo.og.*`, `seo.twitter.title`, `seo.favicon#@href` in pages/properties.html.
+- SEO: added `seo.description`, `seo.og.*`, `seo.twitter.title`, `seo.favicon#@href` in pages/properties.html; favicon field added on index and about.
 - Navigation: logo `nav.logo.href#@href`, `nav.logo.src#@src`, `nav.logo.alt`, toggle `nav.toggle.icon`, `nav.toggle.label`.
 - Properties page: hero `hero.image#@src/alt`, grid `properties[i].image#@src/alt`, `title`, `price`, `address`, `description`, `badges[0..]`, `url#@href`, `url.label`, `location.icon`; how-it-works `howItWorks.bg.src`, `howItWorks.steps` with per-step `.icon` and `.stepNumber`; back-to-top `backToTop.href#@href`, `backToTop.icon`.
+- About page: nav scope + logo/toggler; hero + about images annotated; subscribe fields (placeholder, icon, invalidMessage); back-to-top; footer logo `footer.logo#@src/alt`.
+- Index page: nav scope + logo/toggler; hero images (desktop/mobile src/alt), about teaser image; back-to-top.

--- a/ANNOTATION_MAP.md
+++ b/ANNOTATION_MAP.md
@@ -18,4 +18,6 @@ Pages annotated for inline editing
 Notes
 
 - Existing fields (already present in code): `title`, `heroHeading`, `heroSubheading`, `sections[...]`, `properties[...]` remain intact.
-- Next steps: add `data-sb-alt-field` for key images and annotate CTA links with `data-sb-href-field` per page.
+- SEO: added `seo.description`, `seo.og.*`, `seo.twitter.title`, `seo.favicon#@href` in pages/properties.html.
+- Navigation: logo `nav.logo.href#@href`, `nav.logo.src#@src`, `nav.logo.alt`, toggle `nav.toggle.icon`, `nav.toggle.label`.
+- Properties page: hero `hero.image#@src/alt`, grid `properties[i].image#@src/alt`, `title`, `price`, `address`, `description`, `badges[0..]`, `url#@href`, `url.label`, `location.icon`; how-it-works `howItWorks.bg.src`, `howItWorks.steps` with per-step `.icon` and `.stepNumber`; back-to-top `backToTop.href#@href`, `backToTop.icon`.

--- a/pages/about.html
+++ b/pages/about.html
@@ -10,26 +10,30 @@
     <link rel="stylesheet" href="../css/fonts.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.2/animation_utility.css">
-    <link rel="icon" type="image/x-icon" href="../image/red_LOGO_Vandore.png?v=2025">
+    <link rel="icon" type="image/x-icon" href="../image/red_LOGO_Vandore.png?v=2025" data-sb-field-path="seo.favicon#@href">
 <title data-i18n="vandore_heritage_about_us" data-sb-field-path="title">Vandore Heritage - par mums</title>
+    <meta name="description" data-sb-field-path="seo.description" content="">
+    <meta property="og:title" data-sb-field-path="seo.og.title" content="">
+    <meta property="og:description" data-sb-field-path="seo.og.description" content="">
+    <meta name="twitter:title" data-sb-field-path="seo.twitter.title" content="">
 </head>
 
 <body>
     <!-- Header -->
     <header class="bg-accent-primary px-5">
-        <nav class="navbar">
+        <nav class="navbar" data-sb-field-path="content/pages/about.json:nav">
             <div class="container-fluid ps-3 gap-3">
                 <div class="me-auto"></div>
                 <div class="logo-container position-absolute start-50 translate-middle-x">
-                    <a class="navbar-brand" href="index.html"><img src="../image/red_LOGO_Vandore.png?v=2025" alt="Vandore Heritage Logo" class="img-fluid"></a>
+                    <a class="navbar-brand" href="index.html" data-sb-field-path="content/pages/about.json:nav.logo.href#@href"><img src="../image/red_LOGO_Vandore.png?v=2025" alt="Vandore Heritage Logo" class="img-fluid" data-sb-field-path="content/pages/about.json:nav.logo.src#@src" data-sb-alt-field="content/pages/about.json:nav.logo.alt"></a>
                 </div>
                 <div class="w-max-content">
-                    <button class="btn btn-toggler-accent" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDark" aria-controls="offcanvasDark"><i class="fa-solid fa-bars"></i>
-                        Menu</button>
+                    <button class="btn btn-toggler-accent" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDark" aria-controls="offcanvasDark"><i class="fa-solid fa-bars" data-sb-field-path="content/pages/about.json:nav.toggle.icon"></i>
+                        <span data-sb-field-path="content/pages/about.json:nav.toggle.label">Menu</span></button>
 
                     <div class="offcanvas offcanvas-end offcanvas-fullwidth text-bg-dark" tabindex="-1" id="offcanvasDark" aria-labelledby="offcanvasRightLabel">
                         <div class="offcanvas-header bg-transparent">
-                            <h5 id="offcanvasRightLabel">Menu</h5>
+                            <h5 id="offcanvasRightLabel" data-sb-field-path="content/pages/about.json:nav.menuTitle">Menu</h5>
                             <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
                         </div>
                         <div class="offcanvas-body">
@@ -317,9 +321,9 @@
                                     <form class="d-flex flex-column h-100 justify-content-center w-100 needs-validation form" novalidate="">
                                         <input type="text" name="action" value="subscribe" hidden="">
                                         <div class="input-group gap-3 mb-xl-2 mb-0 position-relative">
-                                            <input type="email" class="form-control rounded-0 mb-xl-0 mb-3 subscribe" placeholder="Sign Up to Newsletter" name="email" required="">
-                                            <button class="btn btn-accent submit_subscribe rounded-0 gap-2 px-4 py-3" type="submit"><i class="rtmicon rtmicon-arrow-right fw-bold"></i></button>
-                                            <div class="invalid-feedback text-white" data-i18n="please_provide_a_valid_email_format_eg_userexamplecom">
+                                            <input type="email" class="form-control rounded-0 mb-xl-0 mb-3 subscribe" placeholder="Sign Up to Newsletter" name="email" required="" data-sb-field-path="subscribe.placeholder">
+                                            <button class="btn btn-accent submit_subscribe rounded-0 gap-2 px-4 py-3" type="submit"><i class="rtmicon rtmicon-arrow-right fw-bold" data-sb-field-path="subscribe.icon"></i></button>
+                                            <div class="invalid-feedback text-white" data-i18n="please_provide_a_valid_email_format_eg_userexamplecom" data-sb-field-path="subscribe.invalidMessage">
                                                 Lūdzu, norādiet derīgu e -pasta formātu (piemēram, 
 user@example.com).
                                             </div>
@@ -355,32 +359,32 @@ user@example.com).
                         <div class="d-flex flex-row gap-5">
                             <ul class="list-unstyled d-flex flex-column gap-3 accent-color">
                                 <li>
-                                    <a href="index.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="home">
+                                    <a href="index.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="home" data-sb-field-path="content/pages/about.json:footer.nav.0.href#@href content/pages/about.json:footer.nav.0.label#text()[0]">
                                         Mājas
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="about.html" class="link active d-flex flex-row gap-3 align-items-center" data-i18n="about">
+                                    <a href="about.html" class="link active d-flex flex-row gap-3 align-items-center" data-i18n="about" data-sb-field-path="content/pages/about.json:footer.nav.1.href#@href content/pages/about.json:footer.nav.1.label#text()[0]">
                                         Pret
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="properties.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="properties">
+                                    <a href="properties.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="properties" data-sb-field-path="content/pages/about.json:footer.nav.2.href#@href content/pages/about.json:footer.nav.2.label#text()[0]">
                                         Īpašības
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="rentals.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="rentals">
+                                    <a href="rentals.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="rentals" data-sb-field-path="content/pages/about.json:footer.nav.3.href#@href content/pages/about.json:footer.nav.3.label#text()[0]">
                                         Īre
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="service.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="service">
+                                    <a href="service.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="service" data-sb-field-path="content/pages/about.json:footer.nav.4.href#@href content/pages/about.json:footer.nav.4.label#text()[0]">
                                         Sakārtošana
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="contact.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="contact_us">
+                                    <a href="contact.html" class="link d-flex flex-row gap-3 align-items-center" data-i18n="contact_us" data-sb-field-path="content/pages/about.json:footer.nav.5.href#@href content/pages/about.json:footer.nav.5.label#text()[0]">
                                         Sazinieties ar mums
                                     </a>
                                 </li>
@@ -414,7 +418,7 @@ user@example.com).
 
 
     <!-- Back to top button -->
-    <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="rtmicon rtmicon-arrow-up"></i></a>
+    <a href="#" class="back-to-top d-flex align-items-center justify-content-center" data-sb-field-path="content/pages/about.json:backToTop.href#@href"><i class="rtmicon rtmicon-arrow-up" data-sb-field-path="content/pages/about.json:backToTop.icon"></i></a>
 
     <!-- Scripts -->
     <script src="../js/vendor/jquery.min.js"></script>

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -10,26 +10,26 @@
     <link rel="stylesheet" href="../css/fonts.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.2/animation_utility.css">
-    <link rel="icon" type="image/x-icon" href="../image/red_LOGO_Vandore.png?v=2025">
+    <link rel="icon" type="image/x-icon" href="../image/red_LOGO_Vandore.png?v=2025" data-sb-field-path="seo.favicon#@href">
     <title data-i18n="vandore_heritage_contact_us" data-sb-field-path="title">Vandore Heritage - sazinieties ar mums</title>
 </head>
 
 <body>
     <!-- Header -->
     <header class="bg-accent-primary px-5">
-        <nav class="navbar">
+        <nav class="navbar" data-sb-field-path="content/pages/contact.json:nav">
             <div class="container-fluid ps-3 gap-3">
                 <div class="me-auto"></div>
                 <div class="logo-container position-absolute start-50 translate-middle-x" style="margin-top: 2cm;">
-                    <a class="navbar-brand" href="index.html"><img src="../image/red_LOGO_Vandore.png?v=2025" alt="Vandore Heritage" class="img-fluid"></a>
+                    <a class="navbar-brand" href="index.html" data-sb-field-path="content/pages/contact.json:nav.logo.href#@href"><img src="../image/red_LOGO_Vandore.png?v=2025" alt="Vandore Heritage" class="img-fluid" data-sb-field-path="content/pages/contact.json:nav.logo.src#@src" data-sb-alt-field="content/pages/contact.json:nav.logo.alt"></a>
                 </div>
                 <div class="w-max-content" style="margin-top: 0.5cm;">
-                    <button class="btn btn-toggler-accent" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDark" aria-controls="offcanvasDark"><i class="fa-solid fa-bars"></i>
-                        Menu</button>
+                    <button class="btn btn-toggler-accent" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDark" aria-controls="offcanvasDark"><i class="fa-solid fa-bars" data-sb-field-path="content/pages/contact.json:nav.toggle.icon"></i>
+                        <span data-sb-field-path="content/pages/contact.json:nav.toggle.label">Menu</span></button>
 
                     <div class="offcanvas offcanvas-end offcanvas-fullwidth text-bg-dark" tabindex="-1" id="offcanvasDark" aria-labelledby="offcanvasRightLabel">
                         <div class="offcanvas-header bg-transparent">
-                            <h5 id="offcanvasRightLabel">Menu</h5>
+                            <h5 id="offcanvasRightLabel" data-sb-field-path="content/pages/contact.json:nav.menuTitle">Menu</h5>
                             <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
                         </div>
                         <div class="offcanvas-body">

--- a/pages/index.html
+++ b/pages/index.html
@@ -10,26 +10,26 @@
     <link rel="stylesheet" href="../css/fonts.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.2/animation_utility.css">
-    <link rel="icon" type="image/x-icon" href="../image/red_LOGO_Vandore.png?v=2025">
+    <link rel="icon" type="image/x-icon" href="../image/red_LOGO_Vandore.png?v=2025" data-sb-field-path="seo.favicon#@href">
     <title data-i18n="vandore_heritage_homepage" data-sb-field-path="title">Vandore Heritage - mājas lapa</title>
 </head>
 
 <body>
     <!-- Header -->
     <header class="bg-accent-primary px-5">
-        <nav class="navbar">
+        <nav class="navbar" data-sb-field-path="content/pages/index.json:nav">
             <div class="container-fluid ps-3 gap-3">
                 <div class="me-auto"></div>
                 <div class="logo-container position-absolute start-50 translate-middle-x" style="margin-top: 2cm;">
-                    <a class="navbar-brand" href="index.html"><img src="../image/red_LOGO_Vandore.png?v=2025" alt="Vandore Heritage" class="img-fluid"></a>
+                    <a class="navbar-brand" href="index.html" data-sb-field-path="content/pages/index.json:nav.logo.href#@href"><img src="../image/red_LOGO_Vandore.png?v=2025" alt="Vandore Heritage" class="img-fluid" data-sb-field-path="content/pages/index.json:nav.logo.src#@src" data-sb-alt-field="content/pages/index.json:nav.logo.alt"></a>
                 </div>
                 <div class="w-max-content" style="margin-top: 0.5cm;">
-                    <button class="btn btn-toggler-accent" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDark" aria-controls="offcanvasDark"><i class="fa-solid fa-bars"></i>
-                        Menu</button>
+                    <button class="btn btn-toggler-accent" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDark" aria-controls="offcanvasDark"><i class="fa-solid fa-bars" data-sb-field-path="content/pages/index.json:nav.toggle.icon"></i>
+                        <span data-sb-field-path="content/pages/index.json:nav.toggle.label">Menu</span></button>
 
                     <div class="offcanvas offcanvas-end offcanvas-fullwidth text-bg-dark" tabindex="-1" id="offcanvasDark" aria-labelledby="offcanvasRightLabel">
                         <div class="offcanvas-header bg-transparent">
-                            <h5 id="offcanvasRightLabel" data-sb-field-path="heroHeading">Menu</h5>
+                            <h5 id="offcanvasRightLabel" data-sb-field-path="content/pages/index.json:nav.menuTitle">Menu</h5>
                             <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
                         </div>
                         <div class="offcanvas-body">
@@ -1102,7 +1102,7 @@ Kļūdas, lai izvairītos no funkcionālākas dzīves telpas
 
 
     <!-- Back to top button -->
-    <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="rtmicon rtmicon-arrow-up"></i></a>
+    <a href="#" class="back-to-top d-flex align-items-center justify-content-center" data-sb-field-path="content/pages/index.json:backToTop.href#@href"><i class="rtmicon rtmicon-arrow-up" data-sb-field-path="content/pages/index.json:backToTop.icon"></i></a>
 
     <!-- Scripts -->
     <script src="../js/vendor/jquery.min.js"></script>

--- a/pages/properties.html
+++ b/pages/properties.html
@@ -9,26 +9,32 @@
     <link rel="stylesheet" href="../css/fonts.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/shishirraven/animate-on-scroll@v1.2/animation_utility.css">
-    <link rel="icon" type="image/x-icon" href="../image/red_LOGO_Vandore.png?v=2025">
+    <link rel="icon" type="image/x-icon" href="../image/red_LOGO_Vandore.png?v=2025" data-sb-field-path="seo.favicon#@href">
     <title data-i18n="vandore_heritage_properties" data-sb-field-path="title">Vandore Heritage - īpašības</title>
+    <meta name="description" data-sb-field-path="seo.description" content="">
+    <meta property="og:title" data-sb-field-path="seo.og.title" content="">
+    <meta property="og:description" data-sb-field-path="seo.og.description" content="">
+    <meta name="twitter:title" data-sb-field-path="seo.twitter.title" content="">
 </head>
 
 <body class="properties-page">
     <!-- Header -->
     <header class="bg-accent-primary px-5">
-        <nav class="navbar">
+        <nav class="navbar" data-sb-field-path="content/pages/properties.json:nav">
             <div class="container-fluid ps-3 gap-3">
                 <div class="me-auto"></div>
                 <div class="logo-container position-absolute start-50 translate-middle-x" style="margin-top: 2cm;">
-                    <a class="navbar-brand" href="index.html"><img src="../image/red_LOGO_Vandore.png?v=2025" alt="Vandore Heritage" class="img-fluid"></a>
+                    <a class="navbar-brand" href="index.html" data-sb-field-path="content/pages/properties.json:nav.logo.href#@href">
+                        <img src="../image/red_LOGO_Vandore.png?v=2025" alt="Vandore Heritage" class="img-fluid" data-sb-field-path="content/pages/properties.json:nav.logo.src#@src" data-sb-alt-field="content/pages/properties.json:nav.logo.alt">
+                    </a>
                 </div>
                 <div class="w-max-content" style="margin-top: 0.5cm;">
-                    <button class="btn btn-toggler-accent" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDark" aria-controls="offcanvasDark"><i class="fa-solid fa-bars"></i>
-                        Menu</button>
+                    <button class="btn btn-toggler-accent" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDark" aria-controls="offcanvasDark"><i class="fa-solid fa-bars" data-sb-field-path="content/pages/properties.json:nav.toggle.icon"></i>
+                        <span data-sb-field-path="content/pages/properties.json:nav.toggle.label">Menu</span></button>
 
                     <div class="offcanvas offcanvas-end offcanvas-fullwidth text-bg-dark" tabindex="-1" id="offcanvasDark" aria-labelledby="offcanvasRightLabel">
                         <div class="offcanvas-header bg-transparent">
-                            <h5 id="offcanvasRightLabel">Menu</h5>
+                            <h5 id="offcanvasRightLabel" data-sb-field-path="content/pages/properties.json:nav.menuTitle">Menu</h5>
                             <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
                         </div>
                         <div class="offcanvas-body">
@@ -207,7 +213,7 @@
                         </div>
                         <div class="offcanvas-lg offcanvas-start" tabindex="-1" id="filter-drawer" aria-labelledby="filter-drawer-label" style="display:none">
                             <div class="offcanvas-header">
-                                <h5 class="offcanvas-title" id="filter-drawer-label" data-i18n="filters">Filtri</h5>
+                                <h5 class="offcanvas-title" id="filter-drawer-label" data-i18n="filters" data-sb-field-path="filters.title">Filtri</h5>
                                 <button type="button" class="btn-close" data-bs-dismiss="offcanvas" data-bs-target="#filter-drawer" aria-label="Close"></button>
                             </div>
                             <div class="offcanvas-body">
@@ -297,17 +303,17 @@
                                     <h6 class="text-accent fw-bold" data-sb-field-path="properties[0].price">$950,000</h6>
                                 </div>
                                 <div class="d-flex align-items-center mb-2">
-                                    <i class="rtmicon rtmicon-location me-2"></i>
+                                    <i class="rtmicon rtmicon-location me-2" data-sb-field-path="properties[0].location.icon"></i>
                                     <span class="text-muted" data-sb-field-path="properties[0].address">123 Heritage Lane, Riga</span>
                                 </div>
                                 <p class="card-text flex-grow-1" data-sb-field-path="properties[0].description">Elegant historic residence with modern amenities and refined finishes.</p>
                                 <div class="d-flex justify-content-between align-items-center mt-auto">
-                                    <div class="d-flex gap-3">
-                                        <span class="badge bg-light text-dark">4 bed</span>
-                                        <span class="badge bg-light text-dark">3 bath</span>
+                                    <div class="d-flex gap-3" data-sb-field-path="properties[0].badges">
+                                        <span class="badge bg-light text-dark" data-sb-field-path=".0">4 bed</span>
+                                        <span class="badge bg-light text-dark" data-sb-field-path=".1">3 bath</span>
                                     </div>
                                     <a href="property_details.html" class="btn btn-accent btn-sm" data-sb-field-path="properties[0].url#@href">
-                                        <span>View Details</span>
+                                        <span data-sb-field-path="properties[0].url.label">View Details</span>
                                         <i class="rtmicon rtmicon-arrow-up-right ms-1"></i>
                                     </a>
                                 </div>
@@ -323,17 +329,17 @@
                                     <h6 class="text-accent fw-bold" data-sb-field-path="properties[1].price">$750,000</h6>
                                 </div>
                                 <div class="d-flex align-items-center mb-2">
-                                    <i class="rtmicon rtmicon-location me-2"></i>
+                                    <i class="rtmicon rtmicon-location me-2" data-sb-field-path="properties[1].location.icon"></i>
                                     <span class="text-muted" data-sb-field-path="properties[1].address">Downtown Riga</span>
                                 </div>
                                 <p class="card-text flex-grow-1" data-sb-field-path="properties[1].description">Contemporary living space with premium finishes and city views.</p>
                                 <div class="d-flex justify-content-between align-items-center mt-auto">
-                                    <div class="d-flex gap-3">
-                                        <span class="badge bg-light text-dark">3 bed</span>
-                                        <span class="badge bg-light text-dark">2 bath</span>
+                                    <div class="d-flex gap-3" data-sb-field-path="properties[1].badges">
+                                        <span class="badge bg-light text-dark" data-sb-field-path=".0">3 bed</span>
+                                        <span class="badge bg-light text-dark" data-sb-field-path=".1">2 bath</span>
                                     </div>
                                     <a href="property_details.html" class="btn btn-accent btn-sm" data-sb-field-path="properties[1].url#@href">
-                                        <span>View Details</span>
+                                        <span data-sb-field-path="properties[1].url.label">View Details</span>
                                         <i class="rtmicon rtmicon-arrow-up-right ms-1"></i>
                                     </a>
                                 </div>
@@ -349,17 +355,17 @@
                                     <h6 class="text-accent fw-bold" data-sb-field-path="properties[2].price">$1,200,000</h6>
                                 </div>
                                 <div class="d-flex align-items-center mb-2">
-                                    <i class="rtmicon rtmicon-location me-2"></i>
+                                    <i class="rtmicon rtmicon-location me-2" data-sb-field-path="properties[2].location.icon"></i>
                                     <span class="text-muted" data-sb-field-path="properties[2].address">Old Town, Riga</span>
                                 </div>
                                 <p class="card-text flex-grow-1" data-sb-field-path="properties[2].description">Restored historic villa with original architectural details and modern conveniences.</p>
                                 <div class="d-flex justify-content-between align-items-center mt-auto">
-                                    <div class="d-flex gap-3">
-                                        <span class="badge bg-light text-dark">5 bed</span>
-                                        <span class="badge bg-light text-dark">4 bath</span>
+                                    <div class="d-flex gap-3" data-sb-field-path="properties[2].badges">
+                                        <span class="badge bg-light text-dark" data-sb-field-path=".0">5 bed</span>
+                                        <span class="badge bg-light text-dark" data-sb-field-path=".1">4 bath</span>
                                     </div>
                                     <a href="property_details.html" class="btn btn-accent btn-sm" data-sb-field-path="properties[2].url#@href">
-                                        <span>View Details</span>
+                                        <span data-sb-field-path="properties[2].url.label">View Details</span>
                                         <i class="rtmicon rtmicon-arrow-up-right ms-1"></i>
                                     </a>
                                 </div>
@@ -375,17 +381,17 @@
                                     <h6 class="text-accent fw-bold" data-sb-field-path="properties[3].price">$450,000</h6>
                                 </div>
                                 <div class="d-flex align-items-center mb-2">
-                                    <i class="rtmicon rtmicon-location me-2"></i>
+                                    <i class="rtmicon rtmicon-location me-2" data-sb-field-path="properties[3].location.icon"></i>
                                     <span class="text-muted" data-sb-field-path="properties[3].address">Riga Suburbs</span>
                                 </div>
                                 <p class="card-text flex-grow-1" data-sb-field-path="properties[3].description">Charming townhouse perfect for families, with garden and quiet neighborhood.</p>
                                 <div class="d-flex justify-content-between align-items-center mt-auto">
-                                    <div class="d-flex gap-3">
-                                        <span class="badge bg-light text-dark">2 bed</span>
-                                        <span class="badge bg-light text-dark">2 bath</span>
+                                    <div class="d-flex gap-3" data-sb-field-path="properties[3].badges">
+                                        <span class="badge bg-light text-dark" data-sb-field-path=".0">2 bed</span>
+                                        <span class="badge bg-light text-dark" data-sb-field-path=".1">2 bath</span>
                                     </div>
                                     <a href="property_details.html" class="btn btn-accent btn-sm" data-sb-field-path="properties[3].url#@href">
-                                        <span>View Details</span>
+                                        <span data-sb-field-path="properties[3].url.label">View Details</span>
                                         <i class="rtmicon rtmicon-arrow-up-right ms-1"></i>
                                     </a>
                                 </div>
@@ -401,17 +407,17 @@
                                     <h6 class="text-accent fw-bold" data-sb-field-path="properties[4].price">$680,000</h6>
                                 </div>
                                 <div class="d-flex align-items-center mb-2">
-                                    <i class="rtmicon rtmicon-location me-2"></i>
+                                    <i class="rtmicon rtmicon-location me-2" data-sb-field-path="properties[4].location.icon"></i>
                                     <span class="text-muted" data-sb-field-path="properties[4].address">Riga Center</span>
                                 </div>
                                 <p class="card-text flex-grow-1" data-sb-field-path="properties[4].description">Stunning penthouse with panoramic city views and luxury amenities.</p>
                                 <div class="d-flex justify-content-between align-items-center mt-auto">
-                                    <div class="d-flex gap-3">
-                                        <span class="badge bg-light text-dark">3 bed</span>
-                                        <span class="badge bg-light text-dark">3 bath</span>
+                                    <div class="d-flex gap-3" data-sb-field-path="properties[4].badges">
+                                        <span class="badge bg-light text-dark" data-sb-field-path=".0">3 bed</span>
+                                        <span class="badge bg-light text-dark" data-sb-field-path=".1">3 bath</span>
                                     </div>
                                     <a href="property_details.html" class="btn btn-accent btn-sm" data-sb-field-path="properties[4].url#@href">
-                                        <span>View Details</span>
+                                        <span data-sb-field-path="properties[4].url.label">View Details</span>
                                         <i class="rtmicon rtmicon-arrow-up-right ms-1"></i>
                                     </a>
                                 </div>
@@ -427,17 +433,17 @@
                                     <h6 class="text-accent fw-bold" data-sb-field-path="properties[5].price">$890,000</h6>
                                 </div>
                                 <div class="d-flex align-items-center mb-2">
-                                    <i class="rtmicon rtmicon-location me-2"></i>
+                                    <i class="rtmicon rtmicon-location me-2" data-sb-field-path="properties[5].location.icon"></i>
                                     <span class="text-muted" data-sb-field-path="properties[5].address">Riga Waterfront</span>
                                 </div>
                                 <p class="card-text flex-grow-1" data-sb-field-path="properties[5].description">Beautiful waterfront property with private dock and stunning river views.</p>
                                 <div class="d-flex justify-content-between align-items-center mt-auto">
-                                    <div class="d-flex gap-3">
-                                        <span class="badge bg-light text-dark">4 bed</span>
-                                        <span class="badge bg-light text-dark">3 bath</span>
+                                    <div class="d-flex gap-3" data-sb-field-path="properties[5].badges">
+                                        <span class="badge bg-light text-dark" data-sb-field-path=".0">4 bed</span>
+                                        <span class="badge bg-light text-dark" data-sb-field-path=".1">3 bath</span>
                                     </div>
                                     <a href="property_details.html" class="btn btn-accent btn-sm" data-sb-field-path="properties[5].url#@href">
-                                        <span>View Details</span>
+                                        <span data-sb-field-path="properties[5].url.label">View Details</span>
                                         <i class="rtmicon rtmicon-arrow-up-right ms-1"></i>
                                     </a>
                                 </div>
@@ -453,16 +459,16 @@
             </div>
         </div>
 
-        <div class="section bg-attach-cover" style="background-image: url(../image/bg_cta.png);">
+        <div class="section bg-attach-cover" style="background-image: url(../image/bg_cta.png);" data-sb-field-path="howItWorks.bg.src">
             <!-- Section How It Work -->
             <div class="r-container d-flex flex-column" style="gap: 140px;">
-                <div class="d-flex flex-xl-row flex-column gap-5 justify-content-between align-items-center position-relative  scrollanimation animated fadeIn adr-7">
+                <div class="d-flex flex-xl-row flex-column gap-5 justify-content-between align-items-center position-relative  scrollanimation animated fadeIn adr-7" data-sb-field-path="howItWorks.steps">
                     <div class="devider-progress"></div>
-                    <div class="d-flex flex-column gap-5 align-items-center">
+                    <div class="d-flex flex-column gap-5 align-items-center" data-sb-field-path=".0">
                         <div class="icon-box active position-relative">
-                            <i class="rtmicon rtmicon-search"></i>
+                            <i class="rtmicon rtmicon-search" data-sb-field-path=".icon"></i>
                             <div class="position-absolute top-0 end-0 p-1 align-items-center text-center justify-content-center rounded-pill bg-black-1" style="width: 36px; height: 36px; margin-top: -15px; margin-right: -15px;">
-                                <h6 class="accent-primary m-0" data-i18n="1">1.</h6>
+                                <h6 class="accent-primary m-0" data-i18n="1" data-sb-field-path=".stepNumber">1.</h6>
                             </div>
                         </div>
                         <div class="d-flex flex-column text-center">
@@ -470,11 +476,11 @@
                             <p class="accent-color-4" style="max-width: 300px;" data-i18n="browse_curated_listings_and_find_a_space_that_truly_fits_your_needs">Pārlūkojiet veidotus sarakstus un atrodiet vietu, kas patiesi atbilst jūsu vajadzībām.</p>
                         </div>
                     </div>
-                    <div class="d-flex flex-column gap-5 align-items-center">
+                    <div class="d-flex flex-column gap-5 align-items-center" data-sb-field-path=".1">
                         <div class="icon-box position-relative">
-                            <i class="rtmicon rtmicon-client-happy"></i>
+                            <i class="rtmicon rtmicon-client-happy" data-sb-field-path=".icon"></i>
                             <div class="position-absolute top-0 end-0 p-1 align-items-center text-center justify-content-center rounded-pill bg-black-1" style="width: 36px; height: 36px; margin-top: -15px; margin-right: -15px;">
-                                <h6 class="accent-primary m-0" data-i18n="2">2.</h6>
+                                <h6 class="accent-primary m-0" data-i18n="2" data-sb-field-path=".stepNumber">2.</h6>
                             </div>
                         </div>
                         <div class="d-flex flex-column text-center">
@@ -482,11 +488,11 @@
                             <p class="accent-color-4" style="max-width: 300px;" data-i18n="receive_clear_practical_guidance_from_advisors_who_stay_with_you_through_the_entire_process">Saņemiet skaidrus, praktiskus norādījumus no padomniekiem, kuri paliek pie jums visā procesā.</p>
                         </div>
                     </div>
-                    <div class="d-flex flex-column gap-5 align-items-center">
+                    <div class="d-flex flex-column gap-5 align-items-center" data-sb-field-path=".2">
                         <div class="icon-box position-relative">
-                            <i class="rtmicon rtmicon-envelope-dollar"></i>
+                            <i class="rtmicon rtmicon-envelope-dollar" data-sb-field-path=".icon"></i>
                             <div class="position-absolute top-0 end-0 p-1 align-items-center text-center justify-content-center rounded-pill bg-black-1" style="width: 36px; height: 36px; margin-top: -15px; margin-right: -15px;">
-                                <h6 class="accent-primary m-0" data-i18n="3">3.</h6>
+                                <h6 class="accent-primary m-0" data-i18n="3" data-sb-field-path=".stepNumber">3.</h6>
                             </div>
                         </div>
                         <div class="d-flex flex-column text-center">
@@ -522,9 +528,9 @@
                                     <form class="d-flex flex-column h-100 justify-content-center w-100 needs-validation form" novalidate="">
                                         <input type="text" name="action" value="subscribe" hidden="">
                                         <div class="input-group gap-3 mb-xl-2 mb-0 position-relative">
-                                            <input type="email" class="form-control rounded-0 mb-xl-0 mb-3 subscribe" placeholder="Join Our Newsletter" name="email" required="">
-                                            <button class="btn btn-accent submit_subscribe rounded-0 gap-2 px-4 py-3" type="submit"><i class="rtmicon rtmicon-arrow-right fw-bold"></i></button>
-                                            <div class="invalid-feedback text-white" data-i18n="please_enter_a_valid_email_eg_userexamplecom">
+                                            <input type="email" class="form-control rounded-0 mb-xl-0 mb-3 subscribe" placeholder="Join Our Newsletter" name="email" required="" data-sb-field-path="subscribe.placeholder">
+                                            <button class="btn btn-accent submit_subscribe rounded-0 gap-2 px-4 py-3" type="submit"><i class="rtmicon rtmicon-arrow-right fw-bold" data-sb-field-path="subscribe.icon"></i></button>
+                                            <div class="invalid-feedback text-white" data-i18n="please_enter_a_valid_email_eg_userexamplecom" data-sb-field-path="subscribe.invalidMessage">
                                                 Lūdzu, ievadiet derīgu e -pastu (piemēram, user@example.com).
                                             </div>
                                         </div>
@@ -534,7 +540,7 @@
                         </div>
                     </div>
                     <div class="col col-xl-5 mb-3 scrollanimation animated fadeInRight">
-                        <img src="../image/dummy-img-900x600.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Vandore Heritage">
+                        <img src="../image/dummy-img-900x600.jpg" class="img-fluid custom-border rounded-2 w-100" alt="Vandore Heritage" data-sb-field-path="subscribe.image#@src" data-sb-alt-field="subscribe.image#@alt">
                     </div>
                 </div>
             </div>
@@ -551,7 +557,7 @@
                             <p class="gray" data-i18n="get_contact">Sazināties</p>
                             <h1 class="fw-normal" data-i18n="infovandoreheritagelv">info@vandoreheritage.lv</h1>
                         </div>
-                        <img src="../image/logo-footer.png?v=2025" alt="Vandore Heritage" class="img-fluid" width="938">
+                        <img src="../image/logo-footer.png?v=2025" alt="Vandore Heritage" class="img-fluid" width="938" data-sb-field-path="content/pages/properties.json:footer.logo#@src" data-sb-alt-field="content/pages/properties.json:footer.logo#@alt">
                     </div>
                 </div>
                 <div class="col col-xl-4 mb-3">
@@ -618,7 +624,7 @@
 
 
     <!-- Back to top button -->
-    <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="rtmicon rtmicon-arrow-up"></i></a>
+    <a href="#" class="back-to-top d-flex align-items-center justify-content-center" data-sb-field-path="content/pages/properties.json:backToTop.href#@href"><i class="rtmicon rtmicon-arrow-up" data-sb-field-path="content/pages/properties.json:backToTop.icon"></i></a>
 
     <!-- Scripts -->
     <script src="../js/vendor/jquery.min.js"></script>


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added Stackbit inline-edit annotations across index, about, contact, and properties pages, plus basic SEO fields. This lets editors update navigation, property listings, CTAs, and back-to-top links without code changes.

- New Features
  - SEO: meta description, Open Graph/Twitter titles, and editable favicon (properties; favicon also on index/about/contact).
  - Navigation: editable scope with logo href/src/alt, toggler icon/label, and menu title on all updated pages.
  - Properties page: annotated property cards (image src/alt, title, price, address, badges, link href/label, location icon), Filters title, How It Works (bg image, per-step icon/number), Subscribe (placeholder, icon, invalid message, image src/alt), Footer logo, and Back-to-top.
  - About page: Subscribe (placeholder, icon, invalid message), Footer nav links, and Back-to-top.
  - Index and Contact pages: nav scope with logo/toggler/menu title, and Back-to-top (index).
  - Docs: ANNOTATION_MAP.md updated to reflect new fields and coverage.

<!-- End of auto-generated description by cubic. -->

